### PR TITLE
Return 500 when reload handler fails

### DIFF
--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadHandler.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadHandler.java
@@ -3,7 +3,6 @@ package me.seroperson.reload.live.webserver;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
-import io.undertow.util.StatusCodes;
 import me.seroperson.reload.live.UnrecoverableException;
 import me.seroperson.reload.live.build.BuildLogger;
 import me.seroperson.reload.live.build.ReloadableServer;
@@ -39,10 +38,7 @@ class ReloadHandler implements HttpHandler {
       server.close();
     } catch (Exception e) {
       logger.error("Error during reloading", e);
-      if (!httpServerExchange.isResponseStarted()) {
-        httpServerExchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
-      }
-      httpServerExchange.endExchange();
+      httpServerExchange.setStatusCode(500);
     }
   }
 }

--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadHandler.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadHandler.java
@@ -3,6 +3,7 @@ package me.seroperson.reload.live.webserver;
 import io.undertow.server.HttpHandler;
 import io.undertow.server.HttpServerExchange;
 import io.undertow.util.AttachmentKey;
+import io.undertow.util.StatusCodes;
 import me.seroperson.reload.live.UnrecoverableException;
 import me.seroperson.reload.live.build.BuildLogger;
 import me.seroperson.reload.live.build.ReloadableServer;
@@ -38,6 +39,10 @@ class ReloadHandler implements HttpHandler {
       server.close();
     } catch (Exception e) {
       logger.error("Error during reloading", e);
+      if (!httpServerExchange.isResponseStarted()) {
+        httpServerExchange.setStatusCode(StatusCodes.INTERNAL_SERVER_ERROR);
+      }
+      httpServerExchange.endExchange();
     }
   }
 }


### PR DESCRIPTION
Closes #7

## Summary

Fixes reload failure handling in `ReloadHandler`.

When reload throws an exception, the proxy now returns `500 Internal Server Error` and ends the exchange instead of leaving the client request hanging.

## Changes

- Add `500` response for generic reload errors.
- Call `endExchange()` after logging the error.
- Avoid overriding the status if the response has already started.

## Testing

- `git diff --check` passed.
- `./gradlew :core:webserver:compileJava` could not run locally because Java 17 toolchain is missing; this machine only has JDK 25.