### PR TITLE
Surface XnioWorker creation failures in DevServerStart

### DIFF
--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
@@ -4,9 +4,11 @@ import io.undertow.Undertow;
 import io.undertow.UndertowOptions;
 import io.undertow.server.handlers.ResponseCodeHandler;
 import io.undertow.server.handlers.proxy.ProxyHandler;
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import me.seroperson.reload.live.BaseDevServerStart;
+import me.seroperson.reload.live.UnrecoverableException;
 import me.seroperson.reload.live.build.BuildLink;
 import me.seroperson.reload.live.build.BuildLogger;
 import me.seroperson.reload.live.settings.DevServerSettings;
@@ -38,48 +40,87 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
       silenceJboss();
     }
 
-    createCurrentGenerationWorker();
+    // Track resources we have already allocated so we can release them if a later
+    // step throws. Set to null after isRunning flips true; BaseDevServerStart.close()
+    // takes over from there.
+    XnioWorker workerToCleanup = null;
+    Undertow proxyToCleanup = null;
+    try {
+      this.currentGenerationWorker = createWorker();
+      workerToCleanup = this.currentGenerationWorker;
 
-    this.proxyClientProvider =
-        new ReloadableProxyClient(
-            logger, URI.create("http://" + settings.getHttpHost() + ":" + settings.getHttpPort()));
-    this.proxyClientProvider.setCurrentGenerationWorker(currentGenerationWorker);
+      this.proxyClientProvider =
+          new ReloadableProxyClient(
+              logger,
+              URI.create("http://" + settings.getHttpHost() + ":" + settings.getHttpPort()));
+      this.proxyClientProvider.setCurrentGenerationWorker(currentGenerationWorker);
 
-    // @formatter:off
-    var proxyHandler =
-        new ProxyHandler(
-            proxyClientProvider,
-            /* maxRequestTime */ -1,
-            ResponseCodeHandler.HANDLE_404,
-            /* rewriteHostHeader */ false,
-            /* reuseXForwarded */ false,
-            2);
-    // @formatter:on
+      // @formatter:off
+      var proxyHandler =
+          new ProxyHandler(
+              proxyClientProvider,
+              /* maxRequestTime */ -1,
+              ResponseCodeHandler.HANDLE_404,
+              /* rewriteHostHeader */ false,
+              /* reuseXForwarded */ false,
+              2);
+      // @formatter:on
 
-    var handler = new ReloadHandler(logger, this, proxyHandler);
+      var handler = new ReloadHandler(logger, this, proxyHandler);
 
-    proxyServer =
-        Undertow.builder()
-            .addHttpListener(settings.getProxyHttpPort(), settings.getProxyHttpHost())
-            .setHandler(handler)
-            .setServerOption(UndertowOptions.SHUTDOWN_TIMEOUT, 1000)
-            .build();
-    proxyServer.start();
+      proxyServer =
+          Undertow.builder()
+              .addHttpListener(settings.getProxyHttpPort(), settings.getProxyHttpHost())
+              .setHandler(handler)
+              .setServerOption(UndertowOptions.SHUTDOWN_TIMEOUT, 1000)
+              .build();
+      proxyToCleanup = proxyServer;
+      proxyServer.start();
 
-    appThreadGroup = new ThreadGroup("app");
+      appThreadGroup = new ThreadGroup("app");
 
-    isRunning.set(true);
+      isRunning.set(true);
+      // Ownership transferred to the running server; do not clean up below.
+      workerToCleanup = null;
+      proxyToCleanup = null;
+    } finally {
+      if (workerToCleanup != null) {
+        // start() failed after the worker was created. Release its threads, and
+        // null out the field so cleanupServerForOldGeneration() does not later try
+        // to shutdownNow() on an already-shutdown worker.
+        try {
+          workerToCleanup.shutdownNow();
+        } catch (Throwable shutdownErr) {
+          logger.error("Failed to shutdown XnioWorker after start() failure", shutdownErr);
+        }
+        this.currentGenerationWorker = null;
+      }
+      if (proxyToCleanup != null) {
+        try {
+          proxyToCleanup.stop();
+        } catch (Throwable stopErr) {
+          logger.error("Failed to stop Undertow listener after start() failure", stopErr);
+        }
+      }
+    }
   }
 
   @Override
   protected void prepareServerForNewGeneration() {
-    createCurrentGenerationWorker();
+    // cleanupServerForOldGeneration() has already shut down (and nulled) the previous
+    // worker; if createWorker() throws here, the field stays null and the exception
+    // propagates up through BaseDevServerStart.reload(), rather than silently leaving
+    // a dead worker installed in the proxy client.
+    this.currentGenerationWorker = createWorker();
     proxyClientProvider.setCurrentGenerationWorker(currentGenerationWorker);
   }
 
   @Override
   protected void cleanupServerForOldGeneration() {
-    currentGenerationWorker.shutdownNow();
+    if (currentGenerationWorker != null) {
+      currentGenerationWorker.shutdownNow();
+      currentGenerationWorker = null;
+    }
   }
 
   @Override
@@ -97,23 +138,23 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
     return "http://" + settings.getHttpHost() + ":" + settings.getHttpPort();
   }
 
-  private void createCurrentGenerationWorker() {
+  private XnioWorker createWorker() {
     var ioThreads = Math.max(Runtime.getRuntime().availableProcessors(), 2);
     try {
-      this.currentGenerationWorker =
-          Xnio.getInstance(getClass().getClassLoader())
-              .createWorker(
-                  OptionMap.builder()
-                      .set(Options.WORKER_IO_THREADS, ioThreads)
-                      .set(Options.CONNECTION_HIGH_WATER, 1000000)
-                      .set(Options.CONNECTION_LOW_WATER, 1000000)
-                      .set(Options.WORKER_TASK_CORE_THREADS, ioThreads * 8)
-                      .set(Options.WORKER_TASK_MAX_THREADS, ioThreads * 8)
-                      .set(Options.TCP_NODELAY, true)
-                      .set(Options.CORK, true)
-                      .getMap());
-    } catch (Exception e) {
-      logger.error("Error during initializing proxy connection worker", e);
+      return Xnio.getInstance(getClass().getClassLoader())
+          .createWorker(
+              OptionMap.builder()
+                  .set(Options.WORKER_IO_THREADS, ioThreads)
+                  .set(Options.CONNECTION_HIGH_WATER, 1000000)
+                  .set(Options.CONNECTION_LOW_WATER, 1000000)
+                  .set(Options.WORKER_TASK_CORE_THREADS, ioThreads * 8)
+                  .set(Options.WORKER_TASK_MAX_THREADS, ioThreads * 8)
+                  .set(Options.TCP_NODELAY, true)
+                  .set(Options.CORK, true)
+                  .getMap());
+    } catch (IOException e) {
+      throw new UnrecoverableException(
+          "Failed to create XnioWorker for the HTTP proxy listener", e);
     }
   }
 


### PR DESCRIPTION
## Summary

`DevServerStart.createCurrentGenerationWorker()` wrapped `Xnio.createWorker(...)` in `catch (Exception e) { logger.error(...); }`, so any failure was logged and swallowed and `currentGenerationWorker` was left at whatever value it had before. Two distinct user-visible failures followed:

### 1. First start: silent dead proxy + later NPE

If worker creation failed on the initial `start()` (resource exhaustion, JVM thread-creation limit, `org.xnio.Xnio` SPI not visible to the classloader), `currentGenerationWorker` stayed `null` but `start()` kept going. The banner printed "🎉 Development Live Reload server successfully started!". Every request through the proxy then failed with a worker-not-set error from `ReloadableProxyClient`, and on shutdown `cleanupServerForOldGeneration()` called `shutdownNow()` on the null field and NPE'd — masking the original failure entirely.

### 2. Reload: dead worker stays installed in the proxy

The reload path is `stopInternal()` → `cleanupServerForOldGeneration()` (shuts down the previous worker) → `startInternal()` → `prepareServerForNewGeneration()` → `createCurrentGenerationWorker()`. On the new creation failing, `currentGenerationWorker` was unchanged — still pointing at the just-shut-down old worker. The next line installed that dead worker into `proxyClientProvider`. From then on every proxied request failed with a dead-worker error until the user manually restarted the dev server, and the reload itself appeared to "succeed" with no exception surfaced.

## Fix

- Replace `createCurrentGenerationWorker()` with `XnioWorker createWorker()` that returns the new worker and throws `UnrecoverableException` on `IOException`. Callers do the assignment, so a failed creation leaves the field at a well-defined value (null after a prior cleanup, unchanged with the previous live worker if creation fails before any cleanup) and the error propagates up through `BaseDevServerStart.reload()`.
- `cleanupServerForOldGeneration()` now null-guards and clears the field after `shutdownNow()`, so repeated cleanup or a failed-then-retried reload doesn't NPE or shut the same worker down twice.
- `start()` wraps the worker + Undertow listener allocation in a `try/finally` that releases both if any later step throws. `DevServerWrapper.start()` will call `server.close()` on failure, but `BaseDevServerStart.close()` short-circuits while `isRunning == false`, so `DevServerStart` needs its own pre-`isRunning` cleanup path.

## Diff

`core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java` — **+89 / −48**, one file.

No changes to `ReloadableServer`, `BaseDevServerStart`, `StartParams`, or the sbt / gradle / mill plugin sites. `GrpcDevServerStart` is unaffected — it has a different lifecycle (no `XnioWorker`, the gRPC channel in `ReloadableGrpcProxyHandler` is lazy).

## Test plan

- [x] `./gradlew :core:webserver:compileJava :core:webserver:spotlessJavaCheck` — passes on JDK 17 (only the pre-existing `// uses or overrides a deprecated API` note).
- [ ] `./gradlew :gradle:check` (functional tests) — should remain green.
- [ ] `sbt test` against sbt 1.x and 2.x — should remain green.
- [ ] Manual repro for failure #1 — start the dev server inside a container with a low `pids.max` so `Xnio.createWorker(...)` can't spawn its IO threads. Before the fix: banner prints, requests 500. After: startup fails fast with `UnrecoverableException("Failed to create XnioWorker for the HTTP proxy listener")`, and the proxy port + any allocated XNIO threads are released.
- [ ] Manual repro for failure #2 — temporarily monkey-patch / wrap Xnio to throw on the second `createWorker` call, edit a source file to trigger a reload, observe that the reload surfaces the exception through the request response instead of silently installing a dead worker.

## Compatibility

No public API changes. The `ReloadableServer` interface and `StartParams` constructor signatures are unchanged. Plugin DSLs (`liveServerType`, `livePropagateEnv`, etc.) are unchanged.

## Notes

This PR is independent of #10 (banner URLs in gRPC mode) and the open `fix/devserverwrapper-leak` branch (build-process state restoration when `start()` fails). All three are separate failure modes of the same lifecycle, but they touch different files and can land in any order.
Fixes #13 