### PR TITLE
Fix channel race in ReloadableGrpcProxyHandler

### DIFF
--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/ReloadableGrpcProxyHandler.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/ReloadableGrpcProxyHandler.java
@@ -12,7 +12,6 @@ import io.grpc.TlsChannelCredentials;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import me.seroperson.reload.live.UnrecoverableException;
 import me.seroperson.reload.live.build.BuildLogger;
 
@@ -22,6 +21,11 @@ import me.seroperson.reload.live.build.BuildLogger;
  * <p>This handler maintains a connection to the target GRPC server and provides the ability to
  * close and recreate the channel when the application is reloaded, ensuring that the proxy always
  * connects to the latest version of the application.
+ *
+ * <p>Channel lifecycle is coordinated through {@code channelLock}: the lock is held only across the
+ * brief field swap (and the lazy create in {@link #getChannel()}). The actual {@code
+ * shutdown}/{@code awaitTermination} is performed <em>outside</em> the lock so that a slow shutdown
+ * of the old channel does not stall concurrent reads.
  */
 class ReloadableGrpcProxyHandler {
 
@@ -31,7 +35,12 @@ class ReloadableGrpcProxyHandler {
   private final int targetPort;
   private final boolean useTls;
   private final String trustPath;
-  private final AtomicReference<ManagedChannel> channelRef = new AtomicReference<>();
+
+  // Guards every assignment to `channel` and the lazy-create in getChannel(). Reads on the
+  // fast path are unsynchronized (volatile) for performance; correctness is preserved by
+  // never letting the field be momentarily null between a close and a replace.
+  private final Object channelLock = new Object();
+  private volatile ManagedChannel channel;
 
   /**
    * Creates a new reloadable GRPC proxy handler.
@@ -62,16 +71,32 @@ class ReloadableGrpcProxyHandler {
    * @return the managed channel to the target server
    */
   public Channel getChannel() {
-    ManagedChannel channel = channelRef.get();
-    if (channel == null || channel.isShutdown() || channel.isTerminated()) {
-      channel = createChannel();
-      channelRef.set(channel);
+    // Fast path: volatile read. If the channel is live, return it without locking.
+    ManagedChannel current = channel;
+    if (current != null && !current.isShutdown() && !current.isTerminated()) {
+      return current;
     }
-    return channel;
+    // Slow path: lazily create exactly one channel under the lock. Double-checked so that
+    // concurrent callers don't each build their own ManagedChannel (the previous
+    // AtomicReference + plain set() pattern leaked the loser of that race).
+    synchronized (channelLock) {
+      current = channel;
+      if (current == null || current.isShutdown() || current.isTerminated()) {
+        current = createChannel();
+        channel = current;
+      }
+      return current;
+    }
   }
 
   /**
    * Creates a new client call to the target server.
+   *
+   * <p>There is a small inherent window where the channel can be shut down by a concurrent {@link
+   * #refreshChannel()} between {@link #getChannel()} and the eventual {@code start()} on the
+   * returned call, in which case gRPC will surface {@code Status.UNAVAILABLE: Channel shutdown
+   * invoked}. This is the best we can do without ref-counting in-flight calls; external callers
+   * should rely on gRPC's own retry policy for transient failures around a reload boundary.
    *
    * @param methodDescriptor the method to call
    * @param callOptions the call options
@@ -84,27 +109,54 @@ class ReloadableGrpcProxyHandler {
     return getChannel().newCall(methodDescriptor, callOptions);
   }
 
-  /** Refreshes the channel by closing the existing one and creating a new one. */
+  /** Refreshes the channel by installing a new one and shutting down the previous one. */
   public void refreshChannel() {
-    closeChannel();
-    logger.debug("Refreshing GRPC channel to " + targetHost + ":" + targetPort);
-    channelRef.set(createChannel());
+    ManagedChannel previous;
+    ManagedChannel replacement;
+    synchronized (channelLock) {
+      previous = channel;
+      // Build the replacement and publish it before the previous channel is shut down so
+      // concurrent getChannel() callers waiting on the lock never see a momentary null.
+      logger.debug("Refreshing GRPC channel to " + targetHost + ":" + targetPort);
+      replacement = createChannel();
+      channel = replacement;
+    }
+    // Shutdown is performed outside the lock: awaitTermination can block for up to 5s and
+    // there is no reason to make new readers wait for the old channel to drain.
+    if (previous != null) {
+      shutdownChannel(previous);
+    }
   }
 
   /** Closes the current channel if it exists. */
   public void closeChannel() {
-    ManagedChannel channel = channelRef.getAndSet(null);
-    if (channel != null && !channel.isShutdown()) {
-      logger.debug("Closing GRPC channel");
-      channel.shutdown();
-      try {
-        if (!channel.awaitTermination(5, TimeUnit.SECONDS)) {
-          channel.shutdownNow();
-        }
-      } catch (InterruptedException e) {
-        channel.shutdownNow();
-        Thread.currentThread().interrupt();
+    ManagedChannel previous;
+    synchronized (channelLock) {
+      previous = channel;
+      channel = null;
+    }
+    if (previous != null) {
+      shutdownChannel(previous);
+    }
+  }
+
+  /**
+   * Gracefully shuts down a single channel, escalating to {@code shutdownNow()} if it does not
+   * terminate within 5 seconds. Idempotent — safe to call on an already-shutdown channel.
+   */
+  private void shutdownChannel(ManagedChannel ch) {
+    if (ch.isShutdown()) {
+      return;
+    }
+    logger.debug("Closing GRPC channel");
+    ch.shutdown();
+    try {
+      if (!ch.awaitTermination(5, TimeUnit.SECONDS)) {
+        ch.shutdownNow();
       }
+    } catch (InterruptedException e) {
+      ch.shutdownNow();
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #17. `ReloadableGrpcProxyHandler` stored its `ManagedChannel` in an `AtomicReference`, but every mutating site used a plain `get() + set()` pair rather than `compareAndSet` / `getAndUpdate` — so the lock-free pattern produced two distinct correctness problems:

### 1. Channel leak on concurrent create

`getChannel()` did an unlocked read-then-write. Two requests arriving at the same time (very common right after a reload) could both observe `null` / `isShutdown()` and each call `createChannel()`. Only one `set()` won; the loser's `ManagedChannel` was leaked — never `shutdown()`-ed, holding its netty event-loop thread group, socket FDs, and cert chain in memory until JVM exit. `refreshChannel()` made it worse: `closeChannel() → set(null) → createChannel() → set(new)` interleaved with a concurrent `getChannel()` that installed its *own* channel between the null-set and the new-set — `refreshChannel()` then stomped it, orphaning it. Over a long dev session with many reloads this accumulated to thousands of leaked channels, manifesting as `OutOfMemoryError: unable to create native thread` or `too many open files`.

### 2. Use-after-shutdown on shutdown-during-call

`getChannel()`'s `isShutdown()` check was not a useful guard because there was no happens-before relationship between the check and the eventual `newCall()`. A concurrent `closeChannel()` running on the reload thread could shut down a channel reference that a request thread had just received, causing intermittent `Status.UNAVAILABLE: Channel shutdown invoked` replies to clients after every reload.

## Fix

Replace `AtomicReference<ManagedChannel>` with a `volatile ManagedChannel channel` plus a dedicated `final Object channelLock`. The lock guards every write and the lazy-create; reads on the hot path remain unsynchronized.

- **`getChannel()`** — fast volatile-read path returns immediately for a live channel. On null/shutdown, fall back to a double-checked `synchronized (channelLock)` lazy create so concurrent callers don't each build their own channel.
- **`refreshChannel()`** — acquire the lock just long enough to install the replacement (`channel = createChannel()`). The field is never momentarily null, so a `getChannel()` caller waiting on the lock can never see "between" state. The slow `shutdown()` + `awaitTermination(5s)` of the previous channel is performed **outside** the lock so it doesn't stall concurrent readers.
- **`closeChannel()`** — same swap-then-shutdown pattern under the same lock.
- **`shutdownChannel(ManagedChannel)`** — new private helper, idempotent (early-returns if `isShutdown()`), escalates to `shutdownNow()` if the 5-second grace expires, restores interrupt status on `InterruptedException`.

The small inherent window between `getChannel()` and `newCall(...).start()` where a concurrent refresh can shut down the channel under us still exists. It is documented on `newCall()` with a note that gRPC clients should rely on their own retry policy for transient failures around reload boundaries — eliminating the window entirely would require ref-counting in-flight calls, which is overkill for a dev tool.

## Diff

| File | Change |
| --- | --- |
| `core/webserver-grpc/.../ReloadableGrpcProxyHandler.java` | +74 / −22, single file. |

No public API changes — `ReloadableGrpcProxyHandler` is package-private. `ReloadableServer` interface, `StartParams`, and the sbt / gradle / mill plugin DSLs are unchanged. `GrpcDevServerStart` calls `refreshChannel()` / `closeChannel()` exactly the same way it did before.

## Test plan

- [x] `./gradlew :core:webserver-grpc:compileJava :core:webserver-grpc:spotlessJavaCheck` on JDK 17 — passes.
- [ ] `./gradlew :gradle:check` — should remain green.
- [ ] `sbt test` against sbt 1.x and 2.x — `GrpcLiveReloadSpec` should remain green.
- [ ] Manual concurrent-load repro per the issue's **Repro** section: a client at ~100 concurrent unary RPCs/sec, paired with `while true; do touch <src>; sleep 1; done`. Before: `LEAK` warnings under `-Dio.grpc.netty.shaded.io.netty.leakDetection.level=PARANOID`, channel count grows monotonically, intermittent `UNAVAILABLE` after each reload. After: channel `new` count matches channel `shutdown` count over the run, no orphaned channels in a heap dump, no `LEAK` warnings, the residual `UNAVAILABLE` window is reduced to the documented (and unavoidable) race between `getChannel()` and `newCall().start()`.
- [ ] Sanity: a single client with no reloads should produce exactly one channel (the lazy create), and `closeChannel()` at dev-server shutdown should shut down exactly that channel.

## Compatibility

- No public API changes.
- The `reload()`, `getTargetHost()`, `getTargetPort()` accessors are unchanged.
- Behavior under normal load is identical (single channel reused per generation); the fix only changes behaviour under concurrent reload + traffic.

## Impact

User-visible across all gRPC-mode users. Before this fix, long-running dev sessions with realistic traffic eventually died with `OutOfMemoryError: unable to create native thread` or `too many open files`, and every reload produced a brief flurry of `UNAVAILABLE` replies that looked like an app bug rather than a tooling bug. After this fix, channel resources are bounded across the lifetime of the dev server and the post-reload error rate drops to the unavoidable inherent-race window.

## Notes

- The `awaitTermination` timeout (5s) is preserved from the original code. Moving it outside the lock means it no longer blocks readers; a sluggish backend that fails to drain in 5s now only stalls the reload thread, never `getChannel()` callers.
- The `channelLock` is intentionally a dedicated `final Object` rather than `synchronized(this)` — `this` is exposed to external collaborators (`GrpcDevServerStart`, `GrpcProxyHandlerRegistry`) and locking on it would be brittle.
- Independent of any other in-flight PR. Touches only `core/webserver-grpc`.
