### PR TITLE
fix: gRPC proxy ignores configured listen host and binds to all interfaces.

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ First, let's check the list of available options:
 
 | Key                                 | Environment                         | Default     | Description                                                                                                                                         |
 | ----------------------------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `live.reload.proxy.http.host`       | `LIVE_RELOAD_PROXY_HTTP_HOST`       | `0.0.0.0`   | The host for the proxy to start on                                                                                                                  |
+| `live.reload.proxy.http.host`       | `LIVE_RELOAD_PROXY_HTTP_HOST`       | `localhost` | The host for the proxy to start on                                                                                                                  |
 | `live.reload.proxy.http.port`       | `LIVE_RELOAD_PROXY_HTTP_PORT`       | `9000`      | The port for the proxy to listen on                                                                                                                 |
 | `live.reload.http.host`             | `LIVE_RELOAD_HTTP_HOST`             | `localhost` | The host on which your web application starts                                                                                                       |
 | `live.reload.http.port`             | `LIVE_RELOAD_HTTP_PORT`             | `8080`      | The port your web application listens on                                                                                                            |

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcDevServerStart.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcDevServerStart.java
@@ -1,12 +1,13 @@
 package me.seroperson.reload.live.webserver.grpc;
 
-import io.grpc.Grpc;
 import io.grpc.InsecureServerCredentials;
 import io.grpc.Server;
 import io.grpc.ServerCredentials;
 import io.grpc.TlsServerCredentials;
+import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import java.io.File;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.util.List;
 import me.seroperson.reload.live.BaseDevServerStart;
 import me.seroperson.reload.live.UnrecoverableException;
@@ -64,14 +65,18 @@ public class GrpcDevServerStart extends BaseDevServerStart<Server> {
     boolean proxyTls = !(proxyCredentials instanceof InsecureServerCredentials);
 
     try {
+      var proxyAddress =
+          new InetSocketAddress(settings.getProxyGrpcHost(), settings.getProxyGrpcPort());
       proxyServer =
-          Grpc.newServerBuilderForPort(settings.getProxyGrpcPort(), proxyCredentials)
+          NettyServerBuilder.forAddress(proxyAddress, proxyCredentials)
               .fallbackHandlerRegistry(new GrpcProxyHandlerRegistry(logger, proxyHandler))
               .build()
               .start();
 
       logger.info(
-          "🚀 GRPC proxy server started on port "
+          "🚀 GRPC proxy server started on "
+              + settings.getProxyGrpcHost()
+              + ":"
               + settings.getProxyGrpcPort()
               + (proxyTls ? " (TLS)" : "")
               + " -> "

--- a/sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala
@@ -292,6 +292,33 @@ class GrpcLiveReloadSpec extends LiveReloadBase {
     }
   }
 
+  testEach(
+    "grpc-scala3 - proxy respects configured listen host",
+    versions = Seq("1.12.3")
+  ) { sbtVersion =>
+    withRunner(
+      "grpc-scala3",
+      sbtVersion,
+      extraJvmOptions = Seq("-Dlive.reload.proxy.grpc.host=127.0.0.1")
+    ) { (runner, proxyPort) =>
+      val externalAddress = nonLoopbackAddress()
+      assume(
+        externalAddress.nonEmpty,
+        "no non-loopback address available for bind-address verification"
+      )
+
+      runner.run("bgRun")
+      verifyGrpc(
+        "greeter.Greeter",
+        "Greet",
+        "",
+        bytesToHex("Scala3-Hi".getBytes("UTF-8")),
+        proxyPort
+      )
+      verifyTcpClosed(externalAddress.get, proxyPort)
+    }
+  }
+
   testEach("grpc-tls - live reload through full TLS proxy and backend") {
     sbtVersion =>
       withRunner("grpc-tls", sbtVersion) { (runner, proxyPort) =>

--- a/sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala
@@ -315,7 +315,7 @@ class GrpcLiveReloadSpec extends LiveReloadBase {
         bytesToHex("Scala3-Hi".getBytes("UTF-8")),
         proxyPort
       )
-      verifyTcpClosed(externalAddress.get, proxyPort)
+      verifyPortClosed(proxyPort, externalAddress.get)
     }
   }
 

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -2,6 +2,7 @@ package me.seroperson.reload.live
 
 import java.io.IOException
 import java.net.InetSocketAddress
+import java.net.NetworkInterface
 import java.net.Socket
 import java.net.URI
 import java.net.http.HttpClient
@@ -11,6 +12,7 @@ import java.time.Duration
 import me.seroperson.reload.live.sbt.BuildInfo
 import me.seroperson.sbt.testkit.*
 import org.scalatest.funsuite.AnyFunSuite
+import scala.jdk.CollectionConverters.*
 import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
@@ -67,7 +69,8 @@ trait LiveReloadBase extends AnyFunSuite {
 
   protected def withRunner(
       resourceDir: String,
-      sbtVersion: String
+      sbtVersion: String,
+      extraJvmOptions: Seq[String] = Seq.empty
   )(body: (SbtRunner, Int) => Unit): Unit = {
     val (proxyPort, appPort) = nextPortPair()
     val runner = SbtRunner
@@ -75,9 +78,11 @@ trait LiveReloadBase extends AnyFunSuite {
       .withDirectoryFromResources(resourceDir)
       .withSbtVersion(sbtVersion)
       .withJvmOptions(
-        s"-Dproject.version=${BuildInfo.version}",
-        s"-Dtestkit.proxyPort=$proxyPort",
-        s"-Dtestkit.port=$appPort"
+        (Seq(
+          s"-Dproject.version=${BuildInfo.version}",
+          s"-Dtestkit.proxyPort=$proxyPort",
+          s"-Dtestkit.port=$appPort"
+        ) ++ extraJvmOptions)*
       )
       .withAttachedStdio()
       .withDebugLogging()
@@ -94,6 +99,27 @@ trait LiveReloadBase extends AnyFunSuite {
       try {
         sock.connect(new InetSocketAddress("localhost", port), 1000)
         throw new AssertionError(s"Port $port is still accepting connections")
+      } catch {
+        case _: IOException => ()
+      } finally sock.close()
+    }
+  }
+
+  /** Returns a non-loopback local address if the machine has one. */
+  protected def nonLoopbackAddress(): Option[String] =
+    NetworkInterface.getNetworkInterfaces.asScala
+      .filter(iface => iface.isUp && !iface.isLoopback)
+      .flatMap(_.getInetAddresses.asScala)
+      .find(address => !address.isLoopbackAddress && !address.isAnyLocalAddress)
+      .map(_.getHostAddress)
+
+  /** Polls until a TCP connect to `host:port` is refused. */
+  protected def verifyTcpClosed(host: String, port: Int): Unit = {
+    pollUntil(s"TCP connect to $host:$port should be refused") {
+      val sock = new Socket()
+      try {
+        sock.connect(new InetSocketAddress(host, port), 1000)
+        throw new AssertionError(s"$host:$port is still accepting connections")
       } catch {
         case _: IOException => ()
       } finally sock.close()

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -91,14 +91,18 @@ trait LiveReloadBase extends AnyFunSuite {
     finally runner.close()
   }
 
-  /** Polls until a TCP connect to `port` is refused, ie. nothing is listening
+  /** Polls until a TCP connect to `host:port` is refused, ie. nothing is
+    * listening
     */
-  protected def verifyPortClosed(port: Int): Unit = {
-    pollUntil(s"TCP connect to $port should be refused") {
+  protected def verifyPortClosed(
+      port: Int,
+      host: String = "localhost"
+  ): Unit = {
+    pollUntil(s"TCP connect to $host:$port should be refused") {
       val sock = new Socket()
       try {
-        sock.connect(new InetSocketAddress("localhost", port), 1000)
-        throw new AssertionError(s"Port $port is still accepting connections")
+        sock.connect(new InetSocketAddress(host, port), 1000)
+        throw new AssertionError(s"$host:$port is still accepting connections")
       } catch {
         case _: IOException => ()
       } finally sock.close()
@@ -112,19 +116,6 @@ trait LiveReloadBase extends AnyFunSuite {
       .flatMap(_.getInetAddresses.asScala)
       .find(address => !address.isLoopbackAddress && !address.isAnyLocalAddress)
       .map(_.getHostAddress)
-
-  /** Polls until a TCP connect to `host:port` is refused. */
-  protected def verifyTcpClosed(host: String, port: Int): Unit = {
-    pollUntil(s"TCP connect to $host:$port should be refused") {
-      val sock = new Socket()
-      try {
-        sock.connect(new InetSocketAddress(host, port), 1000)
-        throw new AssertionError(s"$host:$port is still accepting connections")
-      } catch {
-        case _: IOException => ()
-      } finally sock.close()
-    }
-  }
 
   protected def verifyHttp(
       path: String,


### PR DESCRIPTION
## Summary
The gRPC live-reload proxy now respects the configured listen host from `live.reload.proxy.grpc.host` / `LIVE_RELOAD_PROXY_GRPC_HOST`.

Previously, the proxy advertised the configured host in the banner, but actually used a port-only gRPC server builder, causing it to bind to all interfaces. This could expose the development gRPC proxy externally even when users configured `127.0.0.1` or `localhost`.
## Related Issue
Fixes #23 
## Change Type
- [x] Bug fix
- [x] Security hardening
- [x] Test coverage
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation-only change
- [ ] Refactor

## What Changed
- Replaced the port-only gRPC server bind path with an address-based bind.
- The gRPC proxy now starts with `settings.getProxyGrpcHost()` and `settings.getProxyGrpcPort()`.
- Updated the startup log to show the actual configured listen address.
- Added a regression test that starts the gRPC proxy with `live.reload.proxy.grpc.host=127.0.0.1`.
- The test verifies:
- gRPC calls still work through localhost.
- Non-loopback local addresses cannot connect to the proxy port.

## Real Behavior Proof

Before the fix, running with:

```sh
-Dlive.reload.proxy.grpc.host=127.0.0.1
```

still produced a socket bound to all interfaces:

```text
LISTEN 0 4096 *:9000 *:*
```

After the fix, the proxy binds only to loopback:

```text
LISTEN 0 4096 [::ffff:127.0.0.1]:9000 *:*
```

A connection attempt to the machine’s non-loopback IPv4 address now fails:

```text
testing 37.60.255.86:9000
Connection refused
```

The fixed server log also reports the real listen address:

```text
GRPC proxy server started on 127.0.0.1:19000 -> localhost:19001
```

## Root Cause

`GrpcDevServerStart` used:

```java
Grpc.newServerBuilderForPort(settings.getProxyGrpcPort(), proxyCredentials)
```

That API only accepts a port and does not apply `settings.getProxyGrpcHost()`.

The fix uses an explicit socket address:

```java
new InetSocketAddress(settings.getProxyGrpcHost(), settings.getProxyGrpcPort())
```

and starts the proxy through:

```java
NettyServerBuilder.forAddress(proxyAddress, proxyCredentials)
```

## Security / Impact

This prevents accidental exposure of the development gRPC proxy on LAN or public interfaces.

Without this fix, users could believe the proxy was bound to `localhost` while it was actually reachable from other network interfaces. Since this is a development proxy, it may expose local application behavior, reload triggers, and unauthenticated gRPC methods.
## Checklist

- [x] Issue reproduced locally before fixing
- [x] Root cause identified
- [x] Fix implemented
- [x] Regression test added
- [x] gRPC proxy still handles local gRPC requests
- [x] Non-loopback access is refused when host is `127.0.0.1`
- [x] sbt compile passed
- [x] focused regression test passed
- [x] Gradle Java compile passed
- [x] formatting checks passed
- [x] No unrelated source changes included