### PR TITLE
fix(runner): close application URLClassLoader in close() (#30)

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
@@ -214,7 +214,15 @@ final class DevServerReloader implements BuildLink, Closeable {
 
   @Override
   public void close() {
+    var cl = currentApplicationClassLoader;
     currentApplicationClassLoader = null;
+    if (cl != null) {
+      try {
+        cl.close();
+      } catch (IOException e) {
+        // best-effort cleanup on shutdown
+      }
+    }
     if (watcher != null) watcher.stop();
   }
 }


### PR DESCRIPTION
## Summary
- Close the application `URLClassLoader` in `DevServerReloader.close()` instead of only nulling the reference, so jar/file descriptors are released deterministically on shutdown.

## Root Cause
`DevServerReloader.close()` (`core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java:215-219`) only did:

```java
currentApplicationClassLoader = null;
if (watcher != null) watcher.stop();
```

The loader is a `NamedURLClassLoader` (extends `URLClassLoader`). `URLClassLoader` keeps cached `JarFile` handles for every jar URL it has loaded from; setting the field to `null` lets the loader become unreachable but does not release those native handles — they stay open until GC happens to collect the loader. In a long-lived sbt/Gradle/Mill daemon, repeated `liveReloadRun` start/stop cycles accumulate leaked file descriptors against the build process.

## Fix
Snapshot the reference, null the field first (so any concurrent reload sees `null` and creates a fresh loader on the next reload), then call `close()` on the snapshot. Catch `IOException` and swallow it — this is best-effort cleanup on the shutdown path; there is nothing useful to do if a jar handle refuses to close.

## Test Plan
- [ ] `core/runner` is a Java-only module with no unit-test framework configured; per `AGENTS.md`, core changes are exercised through plugin integration tests (sbt scripted / Gradle functional / mill integration), none of which observe FD-level state. I did not add a new test because there is no harness here that can assert "jar handle released".
- [x] Verified the change compiles cleanly in isolation; the modified file's only new symbol use is `URLClassLoader#close()` (`IOException` is already imported).
- [x] Confirmed by inspection that `currentApplicationClassLoader` has no other lifetime owner (`BaseDevServerStart.stopInternal` closes its own copy of the loader; this `close()` is reached on `Reloader` teardown which is the dev server's true end-of-life).

Closes #30 