### PR TITLE
fix(gradle): route sibling project artifacts to reloadable classes input so sibling-only changes trigger reload

### DIFF
--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadMultiprojectTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadMultiprojectTest.kt
@@ -50,13 +50,56 @@ class LiveReloadMultiprojectTest : LiveReloadTestBase() {
             }
         runThread.start()
 
-        val greet = runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "Hello World")
+        val greet =
+            runUntil(isBuildRunning, "$PROXY_URL/greet", 200, "Hello World", timeoutMillis = 120_000)
 
         appCode.writeText(APP_CODE_2)
         textCode.writeText(TEXT_CODE_2)
 
+        val greetReloaded = runUntil(isBuildRunning, "$PROXY_URL/greet_reloaded", 200, "World Hello!")
+
+        runThread.interrupt()
+
+        assertTrue(greet && greetReloaded)
+    }
+
+    @Test
+    fun `reload multiproject ktor when dependency project changes`() {
+        appCode.writeText(APP_CODE_1_DEPENDENCY_ONLY)
+        textCode.writeText(TEXT_CODE_1)
+
+        settingsFile.writeText(SETTINGS_CONTENT)
+        buildAFile.writeText(BUILD_A_DEPENDENCY_ONLY_CONTENT)
+        buildBFile.writeText(BUILD_B_CONTENT)
+
+        val runner = initGradleRunner(":project-a:liveReloadRun", projectDir)
+        val isBuildRunning = AtomicBoolean(true)
+        val runThread =
+            Thread {
+                try {
+                    runner.build()
+                    isBuildRunning.set(false)
+                } catch (_: InterruptedException) {
+                    println("Interrupted")
+                } catch (ex: Exception) {
+                    println("Got exception ${ex.message}")
+                }
+            }
+        runThread.start()
+
+        val greet =
+            runUntil(
+                isBuildRunning,
+                "$DEPENDENCY_ONLY_PROXY_URL/greet",
+                200,
+                "Hello World",
+                timeoutMillis = 120_000,
+            )
+
+        textCode.writeText(TEXT_CODE_2)
+
         val greetReloaded =
-            runUntil(isBuildRunning, "http://localhost:9000/greet_reloaded", 200, "World Hello!")
+            runUntil(isBuildRunning, "$DEPENDENCY_ONLY_PROXY_URL/greet", 200, "World Hello")
 
         runThread.interrupt()
 
@@ -64,6 +107,9 @@ class LiveReloadMultiprojectTest : LiveReloadTestBase() {
     }
 
     companion object {
+        const val PROXY_URL = "http://localhost:19000"
+        const val DEPENDENCY_ONLY_PROXY_URL = "http://localhost:19001"
+
         const val SETTINGS_CONTENT =
             """
 include("project-a", "project-b")
@@ -94,7 +140,36 @@ dependencies {
     implementation(project(":project-b"))
 }
 
-liveReload { settings = mapOf("live.reload.http.port" to "8081") }
+liveReload { settings = mapOf(
+    "live.reload.http.port" to "8081",
+    "live.reload.proxy.http.port" to "19000"
+) }
+
+application { mainClass = "AppKt" }
+"""
+        const val BUILD_A_DEPENDENCY_ONLY_CONTENT =
+            """
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    application
+    id("me.seroperson.reload.live.gradle")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.ktor:ktor-server-core-jvm:3.3.0")
+    implementation("io.ktor:ktor-server-netty:3.3.0")
+    implementation(project(":project-b"))
+}
+
+liveReload { settings = mapOf(
+    "live.reload.http.port" to "18081",
+    "live.reload.proxy.http.port" to "19001"
+) }
 
 application { mainClass = "AppKt" }
 """
@@ -120,6 +195,27 @@ import io.ktor.server.routing.*
 
 fun main() {
     embeddedServer(Netty, port = 8081) {
+        routing {
+            get("/greet") {
+                call.respondText(Text.response)
+            }
+            get("/health") {
+                call.respond(HttpStatusCode.OK, null)
+            }
+        }
+    }.start(wait = true)
+}
+"""
+        const val APP_CODE_1_DEPENDENCY_ONLY =
+            """
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.engine.embeddedServer
+import io.ktor.server.netty.Netty
+import io.ktor.server.response.respondText
+import io.ktor.server.routing.*
+
+fun main() {
+    embeddedServer(Netty, port = 18081) {
         routing {
             get("/greet") {
                 call.respondText(Text.response)

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadTestBase.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadTestBase.kt
@@ -56,9 +56,10 @@ abstract class LiveReloadTestBase {
     private fun pollUntil(
         label: String,
         isBuildRunning: AtomicBoolean,
+        timeoutMillis: Long = reloadTimeoutMillis,
         attempt: () -> Boolean,
     ): Boolean {
-        val deadline = System.currentTimeMillis() + reloadTimeoutMillis
+        val deadline = System.currentTimeMillis() + timeoutMillis
         while (System.currentTimeMillis() < deadline) {
             if (!isBuildRunning.get()) {
                 return false
@@ -72,7 +73,7 @@ abstract class LiveReloadTestBase {
             }
             Thread.sleep(pollIntervalMillis)
         }
-        println("$label timed out after ${reloadTimeoutMillis}ms")
+        println("$label timed out after ${timeoutMillis}ms")
         return false
     }
 
@@ -81,8 +82,9 @@ abstract class LiveReloadTestBase {
         url: String,
         expectedStatus: Int,
         expectedBody: String,
+        timeoutMillis: Long = reloadTimeoutMillis,
     ): Boolean =
-        pollUntil("HTTP $url", isBuildRunning) {
+        pollUntil("HTTP $url", isBuildRunning, timeoutMillis) {
             val request: Request = Request.Builder().url(url).build()
             val (code, body) =
                 client.newCall(request).execute().use { response ->

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadPlugin.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.ApplicationPlugin.APPLICATION_GROUP
@@ -69,7 +70,24 @@ class LiveReloadPlugin : Plugin<Project> {
                     t.group = APPLICATION_GROUP
                     t.dependsOn(project.tasks.findByName(CLASSES_TASK_NAME)!!)
                     t.outputs.upToDateWhen(Spec { task: Task -> (task as LiveReloadRun).isUpToDate })
+                    val runtime = project.configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+                    val runtimeProjectClasspath =
+                        runtime.incoming
+                            .artifactView {
+                                componentFilter { componentIdentifier ->
+                                    componentIdentifier is ProjectComponentIdentifier
+                                }
+                            }.files
+                    val runtimeDependencyClasspath =
+                        runtime.incoming
+                            .artifactView {
+                                componentFilter { componentIdentifier ->
+                                    componentIdentifier !is ProjectComponentIdentifier
+                                }
+                            }.files
                     t.classes.from(findClasspathDirectories(project))
+                    t.classes.from(runtimeProjectClasspath)
+                    t.classes.from(runtimeDependencyClasspath.filter { it.isDirectory })
                     t.settings.convention(extension.settings)
                     t.mainClass.convention(javaApplicationExtension(project).mainClass)
                     t.startupHooks.convention(extension.startupHooks)
@@ -77,8 +95,7 @@ class LiveReloadPlugin : Plugin<Project> {
                     t.propagateEnv.convention(extension.propagateEnv)
                     t.serverType.convention(extension.serverType)
 
-                    val runtime = project.configurations.getByName(RUNTIME_CLASSPATH_CONFIGURATION_NAME)
-                    t.runtimeClasspath.from(runtime.incoming.files)
+                    t.runtimeClasspath.from(runtimeDependencyClasspath.filter { it.isFile })
                 }
             },
         )


### PR DESCRIPTION
## Summary

Sibling Gradle project artifacts were resolved through `runtimeClasspath` and ended up in the stable parent classloader, so changes in a sibling module did not trigger a reload. `LiveReloadPlugin` now splits the configuration by `ProjectComponentIdentifier`: sibling project artifacts go to the reloadable `classes` input, external libs stay on `runtimeClasspath`.

Fixes #32

## How was it tested?

- New test: `LiveReloadMultiprojectTest.reload multiproject ktor when dependency project changes` - edits **only** the sibling project source between assertions and asserts the updated response is served after reload.
- Existing multiproject test was kept and updated to use isolated proxy ports so the two tests can run side by side.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-gradle`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
