### PR TITLE
fix(webserver): mark currentGenerationWorker volatile (#29)

### DIFF
--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadableProxyClient.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadableProxyClient.java
@@ -30,7 +30,7 @@ class ReloadableProxyClient implements ProxyClient {
       AttachmentKey.create(ClientConnection.class);
   private final UndertowClient client;
   private final BuildLogger logger;
-  private XnioWorker currentGenerationWorker;
+  private volatile XnioWorker currentGenerationWorker;
 
   private static final ProxyTarget TARGET = new ProxyTarget() {};
 


### PR DESCRIPTION
## Summary
- Mark `ReloadableProxyClient.currentGenerationWorker` as `volatile` so reads on Undertow I/O threads observe the new worker reference after a reload.

## Root Cause
`ReloadableProxyClient.currentGenerationWorker` (`core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadableProxyClient.java:33`) is written from the reload thread (under `synchronized` in `BaseDevServerStart`) and read on Undertow I/O threads inside `getConnection` (lines 77 and 94) with no synchronization. There is no happens-before edge between writer and reader — per JLS §17.4 the JIT may cache the field in a register. After a reload, an I/O thread may keep dispatching `client.connect(..., currentGenerationWorker, ...)` calls to the previous worker, which has just been `shutdownNow()`-ed in `cleanupServerForOldGeneration`, producing intermittent proxy failures on reload boundaries.

## Fix
Add `volatile` to the field declaration. The setter is the sole writer, so the volatile write/read pair is enough to publish the new reference to all reader threads.

## Test Plan
- [ ] `core/webserver` has no unit-test framework configured; per `AGENTS.md`, core changes are exercised via plugin integration tests (sbt scripted / Gradle functional / mill integration). Memory-visibility races of this kind are not deterministically reproducible in those harnesses, so I did not add a new test. The change is a one-keyword annotation with no behavioral side effects beyond the intended memory-model guarantee.
- [x] Verified by inspection that the field has exactly one writer (`setCurrentGenerationWorker`) and only field reads; `volatile` is sufficient and an `AtomicReference` would be overkill.

Closes #29
