### PR TITLE
fix(runner): close Files.walk stream to stop FD leak on every reload check

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
@@ -111,8 +111,7 @@ final class DevServerReloader implements BuildLink, Closeable {
       long newLastModified =
           cp.stream()
               .filter(File::exists)
-              .flatMap(DevServerReloader::listRecursively)
-              .mapToLong(File::lastModified)
+              .mapToLong(DevServerReloader::maxLastModified)
               .max()
               .orElse(0L);
       var triggered = newLastModified > lastModified;
@@ -202,11 +201,12 @@ final class DevServerReloader implements BuildLink, Closeable {
     }
   }
 
-  private static Stream<File> listRecursively(File file) {
-    try {
-      return Files.walk(file.toPath())
-          .filter(path -> !(Files.isDirectory(path) && path.equals(file.toPath())))
-          .map(Path::toFile);
+  private static long maxLastModified(File file) {
+    try (Stream<Path> s = Files.walk(file.toPath())) {
+      return s.filter(p -> !(Files.isDirectory(p) && p.equals(file.toPath())))
+          .mapToLong(p -> p.toFile().lastModified())
+          .max()
+          .orElse(0L);
     } catch (IOException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
## Summary
- Replace `listRecursively` (which leaked the `Files.walk` stream) with a `maxLastModified` helper that wraps the walk in try-with-resources and computes the per-entry maximum in place, so directory handles are released on every reload check.

## Root Cause
`DevServerReloader.listRecursively` returned an unclosed `Files.walk` stream (`core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java:205-213`) and the caller drained it via `flatMap` (lines 111-117). `Stream.flatMap` consumes elements from inner streams but does not close them, so every reload check leaked one native directory handle per classpath entry — eventually exhausting the JVM's file-descriptor limit during long dev sessions.

## Fix
- Inline the traversal into a new `maxLastModified(File)` helper that wraps `Files.walk` in `try (Stream<Path> s = …)` and computes `max(lastModified)` for that entry before returning.
- Change the caller to `mapToLong(DevServerReloader::maxLastModified).max().orElse(0L)`. The overall semantics are preserved: the value taken across the classpath is still the newest `lastModified` of any non-root path under any existing classpath entry.

No behavior change beyond closing the streams; the directory-root-exclusion filter (`!(Files.isDirectory(path) && path.equals(file.toPath()))`) is kept identical.

## Test Plan
- [ ] `core/runner` is Java-only with no unit-test framework configured; per `AGENTS.md`, core changes are exercised through plugin integration tests (sbt scripted / Gradle functional / mill integration). Those harnesses don't observe FD-level state, so I did not add a new test that would deterministically catch the leak. The fix is the canonical try-with-resources pattern that the `Files.walk` Javadoc explicitly calls out.
- [x] Verified by inspection that the only consumer of the old `listRecursively` was the `lastModified` aggregation at lines 111-117, so the helper can be safely replaced.
- [x] Existing imports (`Stream`, `Path`, `Files`, `IOException`) are all still used by the new helper — no import changes needed.

Closes #28
