### PR TITLE
fix: restart liveReloadRun when deployment handle exists but server s…

### DIFF
--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunRestartTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunRestartTest.kt
@@ -1,7 +1,5 @@
 package me.seroperson.reload.live.gradle
 
-import org.gradle.testkit.runner.TaskOutcome
-import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Timeout
 import org.junit.jupiter.api.io.TempDir
@@ -22,57 +20,48 @@ class LiveReloadRunRestartTest : LiveReloadTestBase() {
     private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
     private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
 
+    /**
+     * Exercises the deployment-handle restart path within a single BuildSession: continuous build
+     * stops the handle, recompiles, and re-runs [LiveReloadRun] against the same registry entry.
+     * Two separate TestKit [GradleRunner.build] calls each get a fresh [DeploymentRegistry] and
+     * would not cover this path.
+     */
     @Test
-    fun `liveReloadRun restarts proxy after previous run stopped`() {
+    fun `liveReloadRun restarts proxy after continuous rebuild stops deployment`() {
         settingsFile.writeText(SETTINGS_CONTENT)
         buildFile.writeText(BUILD_CONTENT)
-        appCode.writeText(APP_CODE)
+        appCode.writeText(APP_CODE_1)
 
         val runner = initGradleRunner(":liveReloadRun", projectDir)
+        runner.withArguments(runner.arguments + "--continuous")
 
-        val firstRunRunning = AtomicBoolean(true)
-        val firstRun =
+        val isBuildRunning = AtomicBoolean(true)
+        val runThread =
             Thread {
                 try {
                     runner.build()
                 } catch (_: InterruptedException) {
-                    println("First liveReloadRun interrupted")
+                    println("liveReloadRun interrupted")
                 } finally {
-                    firstRunRunning.set(false)
+                    isBuildRunning.set(false)
                 }
             }
-        firstRun.start()
+        runThread.start()
 
         assertTrue(
-            runUntil(firstRunRunning, "http://localhost:9000/greet", 200, "Hello World"),
-            "Proxy should respond during the first liveReloadRun",
+            runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "Hello World"),
+            "Proxy should serve the initial greeting",
         )
 
-        firstRun.interrupt()
-        firstRun.join(30_000)
-
-        val secondRunRunning = AtomicBoolean(true)
-        val secondRun =
-            Thread {
-                try {
-                    val result = runner.build()
-                    assertFalse(
-                        result.task(":liveReloadRun")?.outcome == TaskOutcome.UP_TO_DATE,
-                        "Second liveReloadRun should execute, not be skipped as UP-TO-DATE",
-                    )
-                } finally {
-                    secondRunRunning.set(false)
-                }
-            }
-        secondRun.start()
+        appCode.writeText(APP_CODE_2)
 
         assertTrue(
-            runUntil(secondRunRunning, "http://localhost:9000/greet", 200, "Hello World"),
-            "Proxy should respond again after restarting liveReloadRun in the same daemon",
+            runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "World Hello"),
+            "Proxy should serve the recompiled greeting after continuous rebuild restarts the handle",
         )
 
-        secondRun.interrupt()
-        secondRun.join(30_000)
+        runThread.interrupt()
+        runThread.join(30_000)
     }
 
     companion object {
@@ -98,7 +87,7 @@ liveReload { settings = mapOf("live.reload.http.port" to "8081") }
 
 application { mainClass = "AppKt" }
 """
-        const val APP_CODE =
+        const val APP_CODE_1 =
             """
 import io.javalin.Javalin
 
@@ -106,6 +95,23 @@ fun main() {
     val server =
         Javalin.create()
             .get("/greet") { it.result("Hello World") }
+            .get("/health") { it.status(200) }
+    try {
+        server.start(8081)
+        Thread.currentThread().join()
+    } catch (_: InterruptedException) {
+        server.stop()
+    }
+}
+"""
+        const val APP_CODE_2 =
+            """
+import io.javalin.Javalin
+
+fun main() {
+    val server =
+        Javalin.create()
+            .get("/greet") { it.result("World Hello") }
             .get("/health") { it.status(200) }
     try {
         server.start(8081)

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunRestartTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunRestartTest.kt
@@ -22,9 +22,9 @@ class LiveReloadRunRestartTest : LiveReloadTestBase() {
 
     /**
      * Exercises the deployment-handle restart path within a single BuildSession: continuous build
-     * stops the handle, recompiles, and re-runs [LiveReloadRun] against the same registry entry.
-     * Two separate TestKit [GradleRunner.build] calls each get a fresh [DeploymentRegistry] and
-     * would not cover this path.
+     * stops the handle, recompiles, and re-runs [LiveReloadRun] against the same registry entry. Two
+     * separate TestKit [GradleRunner.build] calls each get a fresh [DeploymentRegistry] and would not
+     * cover this path.
      */
     @Test
     fun `liveReloadRun restarts proxy after continuous rebuild stops deployment`() {

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunRestartTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunRestartTest.kt
@@ -1,0 +1,119 @@
+package me.seroperson.reload.live.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class LiveReloadRunRestartTest : LiveReloadTestBase() {
+    @field:TempDir lateinit var projectDir: File
+
+    private val appCode by lazy {
+        val kotlinSources = projectDir.resolve("src/main/kotlin")
+        kotlinSources.mkdirs()
+        kotlinSources.resolve("App.kt")
+    }
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+
+    @Test
+    fun `liveReloadRun restarts proxy after previous run stopped`() {
+        settingsFile.writeText(SETTINGS_CONTENT)
+        buildFile.writeText(BUILD_CONTENT)
+        appCode.writeText(APP_CODE)
+
+        val runner = initGradleRunner(":liveReloadRun", projectDir)
+
+        val firstRunRunning = AtomicBoolean(true)
+        val firstRun =
+            Thread {
+                try {
+                    runner.build()
+                } catch (_: InterruptedException) {
+                    println("First liveReloadRun interrupted")
+                } finally {
+                    firstRunRunning.set(false)
+                }
+            }
+        firstRun.start()
+
+        assertTrue(
+            runUntil(firstRunRunning, "http://localhost:9000/greet", 200, "Hello World"),
+            "Proxy should respond during the first liveReloadRun",
+        )
+
+        firstRun.interrupt()
+        firstRun.join(30_000)
+
+        val secondRunRunning = AtomicBoolean(true)
+        val secondRun =
+            Thread {
+                try {
+                    val result = runner.build()
+                    assertFalse(
+                        result.task(":liveReloadRun")?.outcome == TaskOutcome.UP_TO_DATE,
+                        "Second liveReloadRun should execute, not be skipped as UP-TO-DATE",
+                    )
+                } finally {
+                    secondRunRunning.set(false)
+                }
+            }
+        secondRun.start()
+
+        assertTrue(
+            runUntil(secondRunRunning, "http://localhost:9000/greet", 200, "Hello World"),
+            "Proxy should respond again after restarting liveReloadRun in the same daemon",
+        )
+
+        secondRun.interrupt()
+        secondRun.join(30_000)
+    }
+
+    companion object {
+        const val SETTINGS_CONTENT = ""
+        const val BUILD_CONTENT =
+            """
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    application
+    id("me.seroperson.reload.live.gradle")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.javalin:javalin:6.7.0")
+}
+
+liveReload { settings = mapOf("live.reload.http.port" to "8081") }
+
+application { mainClass = "AppKt" }
+"""
+        const val APP_CODE =
+            """
+import io.javalin.Javalin
+
+fun main() {
+    val server =
+        Javalin.create()
+            .get("/greet") { it.result("Hello World") }
+            .get("/health") { it.status(200) }
+    try {
+        server.start(8081)
+        Thread.currentThread().join()
+    } catch (_: InterruptedException) {
+        server.stop()
+    }
+}
+"""
+    }
+}

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRun.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRun.kt
@@ -10,7 +10,6 @@ import org.gradle.api.tasks.Classpath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.TaskAction
-import org.gradle.deployment.internal.DeploymentHandle
 import org.gradle.deployment.internal.DeploymentRegistry
 import org.gradle.deployment.internal.DeploymentRegistry.ChangeBehavior
 import org.gradle.work.DisableCachingByDefault
@@ -45,8 +44,8 @@ abstract class LiveReloadRun
         @get:Internal
         val isUpToDate: Boolean
             get() {
-                val deploymentHandle = deploymentRegistry.get(path, DeploymentHandle::class.java)
-                return deploymentHandle != null
+                val runHandle = deploymentRegistry.get(path, LiveReloadRunHandle::class.java)
+                return runHandle?.isRunning() == true
             }
 
         @TaskAction
@@ -67,6 +66,9 @@ abstract class LiveReloadRun
                         this.serverType.get(),
                     )
                 deploymentRegistry.start(id, ChangeBehavior.BLOCK, LiveReloadRunHandle::class.java, params)
+            } else if (!runHandle.isRunning()) {
+                logger.lifecycle("Restarting live-reload dev server after previous run stopped")
+                runHandle.restart()
             } else {
                 if (!changes.isIncremental) {
                     logger.info("Reload application by no incremental changes")

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRun.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRun.kt
@@ -48,34 +48,39 @@ abstract class LiveReloadRun
                 return runHandle?.isRunning() == true
             }
 
+        private fun currentParams(): LiveReloadRunParams =
+            LiveReloadRunParams(
+                this.runtimeClasspath.files,
+                this.classes.files,
+                this.settings.get(),
+                this.mainClass.get(),
+                this.startupHooks.get(),
+                this.shutdownHooks.get(),
+                this.propagateEnv.get(),
+                this.serverType.get(),
+            )
+
         @TaskAction
         fun run(changes: InputChanges) {
             val id = path
+            val params = currentParams()
             val runHandle: LiveReloadRunHandle? =
                 deploymentRegistry.get(id, LiveReloadRunHandle::class.java)
             if (runHandle == null) {
-                val params =
-                    LiveReloadRunParams(
-                        this.runtimeClasspath.files,
-                        this.classes.files,
-                        this.settings.get(),
-                        this.mainClass.get(),
-                        this.startupHooks.get(),
-                        this.shutdownHooks.get(),
-                        this.propagateEnv.get(),
-                        this.serverType.get(),
-                    )
                 deploymentRegistry.start(id, ChangeBehavior.BLOCK, LiveReloadRunHandle::class.java, params)
-            } else if (!runHandle.isRunning()) {
-                logger.lifecycle("Restarting live-reload dev server after previous run stopped")
-                runHandle.restart()
             } else {
-                if (!changes.isIncremental) {
-                    logger.info("Reload application by no incremental changes")
-                } else if (changes.getFileChanges(this.classes).iterator().hasNext()) {
-                    logger.info("Reload application by incremental changes in application classpath")
+                runHandle.updateParams(params)
+                if (!runHandle.isRunning()) {
+                    logger.lifecycle("Restarting live-reload dev server after previous run stopped")
+                    runHandle.restart()
                 } else {
-                    logger.info("Incremental changes in Assets")
+                    if (!changes.isIncremental) {
+                        logger.info("Reload application by no incremental changes")
+                    } else if (changes.getFileChanges(this.classes).iterator().hasNext()) {
+                        logger.info("Reload application by incremental changes in application classpath")
+                    } else {
+                        logger.info("Incremental changes in Assets")
+                    }
                 }
             }
         }

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunHandle.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunHandle.kt
@@ -16,8 +16,9 @@ import javax.inject.Inject
 open class LiveReloadRunHandle
     @Inject
     constructor(
-        private val params: LiveReloadRunParams,
+        params: LiveReloadRunParams,
     ) : DeploymentHandle {
+        private var params: LiveReloadRunParams = params
         private var deployment: Deployment? = null
         private var devServer: ReloadableServer? = null
         private val lock: ReadWriteLock = ReentrantReadWriteLock()
@@ -41,6 +42,16 @@ open class LiveReloadRunHandle
             }
         }
 
+        /** Replaces run configuration from the latest [LiveReloadRun] task execution. */
+        fun updateParams(params: LiveReloadRunParams) {
+            lock.writeLock().lock()
+            try {
+                this.params = params
+            } finally {
+                lock.writeLock().unlock()
+            }
+        }
+
         /** Starts the dev server again after [stop] when Gradle re-runs the task. */
         fun restart() {
             lock.writeLock().lock()
@@ -53,7 +64,13 @@ open class LiveReloadRunHandle
                 if (devServer?.isRunning() == true) {
                     return
                 }
-                startDevServer(deployment)
+                closeDevServer()
+                try {
+                    startDevServer(deployment)
+                } catch (e: Exception) {
+                    logger.error("Failed to restart live-reload dev server", e)
+                    throw e
+                }
             } finally {
                 lock.writeLock().unlock()
             }
@@ -87,7 +104,20 @@ open class LiveReloadRunHandle
             }
         }
 
+        private fun closeDevServer() {
+            val server = devServer
+            devServer = null
+            if (server != null) {
+                try {
+                    server.close()
+                } catch (e: Exception) {
+                    logger.error("Error closing live-reload dev server", e)
+                }
+            }
+        }
+
         private fun startDevServer(deployment: Deployment) {
+            closeDevServer()
             val serverClass =
                 when (params.serverType) {
                     ServerType.HTTP -> "me.seroperson.reload.live.webserver.DevServerStart"
@@ -126,12 +156,9 @@ open class LiveReloadRunHandle
             lock.writeLock().lock()
             logger.info("Application is stopping ...")
             try {
-                devServer?.close()
+                closeDevServer()
                 logger.info("Application stopped.")
-            } catch (e: Exception) {
-                logger.error("Application stopped with exception", e)
             } finally {
-                devServer = null
                 lock.writeLock().unlock()
             }
         }

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunHandle.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRunHandle.kt
@@ -35,9 +35,27 @@ open class LiveReloadRunHandle
         override fun isRunning(): Boolean {
             lock.readLock().lock()
             try {
-                return devServer != null
+                return devServer?.isRunning() == true
             } finally {
                 lock.readLock().unlock()
+            }
+        }
+
+        /** Starts the dev server again after [stop] when Gradle re-runs the task. */
+        fun restart() {
+            lock.writeLock().lock()
+            try {
+                val deployment =
+                    deployment
+                        ?: throw IllegalStateException(
+                            "Cannot restart live-reload: deployment handle is not available",
+                        )
+                if (devServer?.isRunning() == true) {
+                    return
+                }
+                startDevServer(deployment)
+            } finally {
+                lock.writeLock().unlock()
             }
         }
 
@@ -63,41 +81,45 @@ open class LiveReloadRunHandle
             lock.writeLock().lock()
             this.deployment = deployment
             try {
-                val serverClass =
-                    when (params.serverType) {
-                        ServerType.HTTP -> "me.seroperson.reload.live.webserver.DevServerStart"
-                        ServerType.GRPC -> "me.seroperson.reload.live.webserver.grpc.GrpcDevServerStart"
-                    }
-                val params =
-                    StartParams(
-                        // todo: deal with args, properties and java options
-                        DevServerSettings(listOf(), listOf(), params.settings),
-                        params.dependencyClasspath.toList(),
-                        // monitoredFiles
-                        listOf(),
-                        serverClass,
-                        params.mainClass,
-                        params.startupHooks,
-                        params.shutdownHooks,
-                        params.propagateEnv,
-                    )
-
-                val buildLogger = LiveReloadLogger()
-                val devServerRunner = DevServerRunner.getInstance()
-                devServer =
-                    devServerRunner.runBackground(
-                        params,
-                        this::reloadCompile,
-                        this::isChanged,
-                        // fileWatcherService
-                        null,
-                        buildLogger,
-                    )
-                // Visible only when running with `--info`
-                DevServerRunner.printBanner(devServer, buildLogger)
+                startDevServer(deployment)
             } finally {
                 lock.writeLock().unlock()
             }
+        }
+
+        private fun startDevServer(deployment: Deployment) {
+            val serverClass =
+                when (params.serverType) {
+                    ServerType.HTTP -> "me.seroperson.reload.live.webserver.DevServerStart"
+                    ServerType.GRPC -> "me.seroperson.reload.live.webserver.grpc.GrpcDevServerStart"
+                }
+            val startParams =
+                StartParams(
+                    // todo: deal with args, properties and java options
+                    DevServerSettings(listOf(), listOf(), params.settings),
+                    params.dependencyClasspath.toList(),
+                    // monitoredFiles
+                    listOf(),
+                    serverClass,
+                    params.mainClass,
+                    params.startupHooks,
+                    params.shutdownHooks,
+                    params.propagateEnv,
+                )
+
+            val buildLogger = LiveReloadLogger()
+            val devServerRunner = DevServerRunner.getInstance()
+            devServer =
+                devServerRunner.runBackground(
+                    startParams,
+                    this::reloadCompile,
+                    this::isChanged,
+                    // fileWatcherService
+                    null,
+                    buildLogger,
+                )
+            // Visible only when running with `--info`
+            DevServerRunner.printBanner(devServer, buildLogger)
         }
 
         override fun stop() {
@@ -110,7 +132,6 @@ open class LiveReloadRunHandle
                 logger.error("Application stopped with exception", e)
             } finally {
                 devServer = null
-                deployment = null
                 lock.writeLock().unlock()
             }
         }


### PR DESCRIPTION
## Summary

Fixes [#27](https://github.com/seroperson/jvm-live-reload/issues/27).

After stopping a previous `liveReloadRun`, a second invocation in the same Gradle daemon could report `UP-TO-DATE` and skip the task action even though no proxy was listening. The up-to-date check only tested whether a `DeploymentHandle` was still registered, not whether the live-reload dev server was actually running.

`liveReloadRun` is now up-to-date only when a `LiveReloadRunHandle` exists **and** its dev server reports running. If a stale handle remains after `stop()`, the task action restarts the dev server instead of only logging incremental classpath changes.

## Changes

- `LiveReloadRun.isUpToDate` — require `LiveReloadRunHandle.isRunning() == true` (delegates to `ReloadableServer.isRunning()`).
- `LiveReloadRun.run` — call `LiveReloadRunHandle.restart()` when a handle exists but the server is stopped.
- `LiveReloadRunHandle` — keep the Gradle `Deployment` after `stop()` so restart is possible; extract `startDevServer()` shared by `start()` and `restart()`.
- New Gradle functional test: `LiveReloadRunRestartTest` (start → verify proxy → stop → run again in same TestKit daemon → verify proxy again).

## How was it tested?

- New functional test: `LiveReloadRunRestartTest` (`liveReloadRun restarts proxy after previous run stopped`)
- Manual repro from the issue:

```sh
GRADLE_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED" \
./gradlew --no-configuration-cache liveReloadRun
# curl proxy, Ctrl+C to stop

GRADLE_OPTS="--add-opens=java.base/java.nio=ALL-UNNAMED" \
./gradlew --no-configuration-cache liveReloadRun
# curl proxy again — should succeed; task must not be UP-TO-DATE
```

```sh
just test-gradle
just code-format-check-all
```

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [x] No unrelated files were reformatted or refactored
