### PR TITLE
fix: concurrent startup requests wait for health check

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
@@ -195,8 +195,9 @@ public abstract class BaseDevServerStart<S> implements ReloadableServer {
         });
   }
 
+  /** Synchronized with {@link #startInternal} so concurrent requests wait for startup hooks. */
   @Override
-  public boolean reload() {
+  public synchronized boolean reload() {
     var reloadResult = buildLink.reload();
     if (reloadResult instanceof ReloadGeneration) {
       var casted = (ReloadGeneration) reloadResult;

--- a/sbt/src/test/resources/http4s-slow-start/build.sbt
+++ b/sbt/src/test/resources/http4s-slow-start/build.sbt
@@ -1,0 +1,33 @@
+val Http4sVersion = "0.23.30"
+
+enablePlugins(LiveReloadPlugin)
+enablePlugins(BuildInfoPlugin)
+
+scalaVersion := "2.13.16"
+resolvers += Resolver.mavenLocal
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-ember-server" % Http4sVersion,
+  "org.http4s" %% "http4s-dsl" % Http4sVersion,
+  "org.typelevel" %% "cats-effect" % "3.6.3"
+)
+
+val isSbt2 = settingKey[Boolean]("isSbt2")
+isSbt2 := (sbtBinaryVersion.value match {
+  case "2" => true
+  case _   => false
+})
+
+val proxyPort = settingKey[Int]("proxyPort")
+proxyPort := sys.props.get("testkit.proxyPort").map(_.toInt).getOrElse(if (isSbt2.value) 9001 else 9000)
+
+val port = settingKey[Int]("port")
+port := sys.props.get("testkit.port").map(_.toInt).getOrElse(if (isSbt2.value) 8081 else 8080)
+
+liveDevSettings := Seq(
+  DevSettingsKeys.LiveReloadProxyHttpPort -> proxyPort.value.toString,
+  DevSettingsKeys.LiveReloadHttpPort -> port.value.toString,
+  DevSettingsKeys.LiveReloadIsDebug -> "true"
+)
+
+buildInfoKeys := Seq[BuildInfoKey](port)
+buildInfoPackage := "me.seroperson"

--- a/sbt/src/test/resources/http4s-slow-start/project/plugins.sbt
+++ b/sbt/src/test/resources/http4s-slow-start/project/plugins.sbt
@@ -1,0 +1,6 @@
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
+resolvers += Resolver.mavenLocal
+
+addSbtPlugin("me.seroperson" % "sbt-live-reload" % sys.props("project.version"))
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")

--- a/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
+++ b/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
@@ -1,0 +1,41 @@
+import cats.effect.Async
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.Sync
+import cats.syntax.all._
+import com.comcast.ip4s._
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.dsl.io._
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.implicits._
+
+object App extends IOApp.Simple {
+
+  def helloWorldRoutes[F[_]: Sync]: HttpRoutes[F] = {
+    val dsl = new Http4sDsl[F] {}
+    import dsl._
+    HttpRoutes.of[F] {
+      case GET -> Root / "greet" =>
+        Ok("hello")
+      case GET -> Root / "greet2" =>
+        Ok("hello")
+      case GET -> Root / "health" =>
+        Ok()
+    }
+  }
+
+  def runServer[F[_]: Async]: F[Nothing] = {
+    for {
+      _ <- Sync[F].delay(Thread.sleep(2000))
+      _ <-
+        EmberServerBuilder
+          .default[F]
+          .withPort(Port.fromInt(me.seroperson.BuildInfo.port).get)
+          .withHttpApp(helloWorldRoutes[F].orNotFound)
+          .build
+    } yield ()
+  }.useForever
+
+  val run = runServer[IO]
+}

--- a/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
+++ b/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
@@ -1,8 +1,8 @@
 import cats.effect.Async
 import cats.effect.IO
 import cats.effect.IOApp
-import cats.effect.Sync
 import cats.effect.Resource
+import cats.effect.Sync
 import cats.effect.Temporal
 import cats.syntax.all._
 import com.comcast.ip4s._

--- a/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
+++ b/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
@@ -2,6 +2,8 @@ import cats.effect.Async
 import cats.effect.IO
 import cats.effect.IOApp
 import cats.effect.Sync
+import cats.effect.Resource
+import cats.effect.Temporal
 import cats.syntax.all._
 import com.comcast.ip4s._
 import org.http4s._
@@ -27,7 +29,7 @@ object App extends IOApp.Simple {
 
   def runServer[F[_]: Async]: F[Nothing] = {
     for {
-      _ <- Sync[F].delay(Thread.sleep(2000))
+      _ <- Resource.eval(Temporal[F].sleep(2.seconds))
       _ <-
         EmberServerBuilder
           .default[F]

--- a/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
+++ b/sbt/src/test/resources/http4s-slow-start/src/main/scala/App.scala
@@ -11,6 +11,7 @@ import org.http4s.dsl.Http4sDsl
 import org.http4s.dsl.io._
 import org.http4s.ember.server.EmberServerBuilder
 import org.http4s.implicits._
+import scala.concurrent.duration._
 
 object App extends IOApp.Simple {
 

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -9,6 +9,7 @@ import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
+import java.util.concurrent.Executors
 import me.seroperson.reload.live.sbt.BuildInfo
 import me.seroperson.sbt.testkit.*
 import org.scalatest.funsuite.AnyFunSuite
@@ -116,6 +117,44 @@ trait LiveReloadBase extends AnyFunSuite {
       .flatMap(_.getInetAddresses.asScala)
       .find(address => !address.isLoopbackAddress && !address.isAnyLocalAddress)
       .map(_.getHostAddress)
+
+  /** Issues concurrent GET requests and expects each to succeed within the reload timeout. */
+  protected def verifyHttpConcurrent(
+      paths: Seq[String],
+      expectedStatus: Int,
+      expectedBody: Option[String] = None,
+      port: Int
+  ): Unit = {
+    val executor = Executors.newFixedThreadPool(paths.size)
+    try {
+      val futures = paths.map { path =>
+        executor.submit(() =>
+          pollUntil(s"HTTP /$path (status=$expectedStatus, body=$expectedBody)") {
+            val request = HttpRequest
+              .newBuilder()
+              .uri(URI.create(s"http://localhost:$port/$path"))
+              .timeout(Duration.ofSeconds(30))
+              .GET()
+              .build()
+            val response =
+              httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+            assert(
+              response.statusCode() == expectedStatus,
+              s"Expected status $expectedStatus for /$path, got ${response.statusCode()}"
+            )
+            expectedBody.foreach { body =>
+              val actualBody = response.body()
+              assert(
+                actualBody == body,
+                s"Expected body '$body' for /$path, got '$actualBody'"
+              )
+            }
+          }
+        )
+      }
+      futures.foreach(_.get())
+    } finally executor.shutdown()
+  }
 
   protected def verifyHttp(
       path: String,

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -118,7 +118,9 @@ trait LiveReloadBase extends AnyFunSuite {
       .find(address => !address.isLoopbackAddress && !address.isAnyLocalAddress)
       .map(_.getHostAddress)
 
-  /** Issues concurrent GET requests and expects each to succeed within the reload timeout. */
+  /** Issues concurrent GET requests and expects each to succeed within the
+    * reload timeout.
+    */
   protected def verifyHttpConcurrent(
       paths: Seq[String],
       expectedStatus: Int,
@@ -129,7 +131,9 @@ trait LiveReloadBase extends AnyFunSuite {
     try {
       val futures = paths.map { path =>
         executor.submit(() =>
-          pollUntil(s"HTTP /$path (status=$expectedStatus, body=$expectedBody)") {
+          pollUntil(
+            s"HTTP /$path (status=$expectedStatus, body=$expectedBody)"
+          ) {
             val request = HttpRequest
               .newBuilder()
               .uri(URI.create(s"http://localhost:$port/$path"))

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -130,33 +130,41 @@ trait LiveReloadBase extends AnyFunSuite {
     val executor = Executors.newFixedThreadPool(paths.size)
     try {
       val futures = paths.map { path =>
-        executor.submit((() =>
-          pollUntil(
-            s"HTTP /$path (status=$expectedStatus, body=$expectedBody)"
-          ) {
-            val request = HttpRequest
-              .newBuilder()
-              .uri(URI.create(s"http://localhost:$port/$path"))
-              .timeout(Duration.ofSeconds(30))
-              .GET()
-              .build()
-            val response =
-              httpClient.send(request, HttpResponse.BodyHandlers.ofString())
-            assert(
-              response.statusCode() == expectedStatus,
-              s"Expected status $expectedStatus for /$path, got ${response.statusCode()}"
-            )
-            expectedBody.foreach { body =>
-              val actualBody = response.body()
-              assert(
-                actualBody == body,
-                s"Expected body '$body' for /$path, got '$actualBody'"
-              )
-            }
-          }): java.lang.Runnable
+        executor.submit(
+          (
+              () =>
+                pollUntil(
+                  s"HTTP /$path (status=$expectedStatus, body=$expectedBody)"
+                ) {
+                  val request = HttpRequest
+                    .newBuilder()
+                    .uri(URI.create(s"http://localhost:$port/$path"))
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build()
+                  val response =
+                    httpClient.send(
+                      request,
+                      HttpResponse.BodyHandlers.ofString()
+                    )
+                  assert(
+                    response.statusCode() == expectedStatus,
+                    s"Expected status $expectedStatus for /$path, got ${response.statusCode()}"
+                  )
+                  expectedBody.foreach { body =>
+                    val actualBody = response.body()
+                    assert(
+                      actualBody == body,
+                      s"Expected body '$body' for /$path, got '$actualBody'"
+                    )
+                  }
+                }
+          ): java.lang.Runnable
         )
       }
-      futures.asInstanceOf[List[java.util.concurrent.Future[_]]].foreach(_.get())
+      futures
+        .asInstanceOf[List[java.util.concurrent.Future[_]]]
+        .foreach(_.get())
     } finally executor.shutdown()
   }
 

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -130,7 +130,7 @@ trait LiveReloadBase extends AnyFunSuite {
     val executor = Executors.newFixedThreadPool(paths.size)
     try {
       val futures = paths.map { path =>
-        executor.submit(() =>
+        executor.submit((() =>
           pollUntil(
             s"HTTP /$path (status=$expectedStatus, body=$expectedBody)"
           ) {
@@ -153,10 +153,10 @@ trait LiveReloadBase extends AnyFunSuite {
                 s"Expected body '$body' for /$path, got '$actualBody'"
               )
             }
-          }
+          }): java.lang.Runnable
         )
       }
-      futures.foreach(_.get())
+      futures.asInstanceOf[List[java.util.concurrent.Future[_]]].foreach(_.get())
     } finally executor.shutdown()
   }
 

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadBase.scala
@@ -13,6 +13,10 @@ import java.util.concurrent.Executors
 import me.seroperson.reload.live.sbt.BuildInfo
 import me.seroperson.sbt.testkit.*
 import org.scalatest.funsuite.AnyFunSuite
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+import scala.concurrent.duration.Duration as ScalaDuration
 import scala.jdk.CollectionConverters.*
 import scala.util.Failure
 import scala.util.Success
@@ -128,43 +132,38 @@ trait LiveReloadBase extends AnyFunSuite {
       port: Int
   ): Unit = {
     val executor = Executors.newFixedThreadPool(paths.size)
+    given ExecutionContext = ExecutionContext.fromExecutor(executor)
     try {
-      val futures = paths.map { path =>
-        executor.submit(
-          (
-              () =>
-                pollUntil(
-                  s"HTTP /$path (status=$expectedStatus, body=$expectedBody)"
-                ) {
-                  val request = HttpRequest
-                    .newBuilder()
-                    .uri(URI.create(s"http://localhost:$port/$path"))
-                    .timeout(Duration.ofSeconds(30))
-                    .GET()
-                    .build()
-                  val response =
-                    httpClient.send(
-                      request,
-                      HttpResponse.BodyHandlers.ofString()
-                    )
-                  assert(
-                    response.statusCode() == expectedStatus,
-                    s"Expected status $expectedStatus for /$path, got ${response.statusCode()}"
-                  )
-                  expectedBody.foreach { body =>
-                    val actualBody = response.body()
-                    assert(
-                      actualBody == body,
-                      s"Expected body '$body' for /$path, got '$actualBody'"
-                    )
-                  }
-                }
-          ): java.lang.Runnable
-        )
-      }
-      futures
-        .asInstanceOf[List[java.util.concurrent.Future[_]]]
-        .foreach(_.get())
+      Await.result(
+        Future.traverse(paths) { path =>
+          Future {
+            pollUntil(
+              s"HTTP /$path (status=$expectedStatus, body=$expectedBody)"
+            ) {
+              val request = HttpRequest
+                .newBuilder()
+                .uri(URI.create(s"http://localhost:$port/$path"))
+                .timeout(Duration.ofSeconds(30))
+                .GET()
+                .build()
+              val response =
+                httpClient.send(request, HttpResponse.BodyHandlers.ofString())
+              assert(
+                response.statusCode() == expectedStatus,
+                s"Expected status $expectedStatus for /$path, got ${response.statusCode()}"
+              )
+              expectedBody.foreach { body =>
+                val actualBody = response.body()
+                assert(
+                  actualBody == body,
+                  s"Expected body '$body' for /$path, got '$actualBody'"
+                )
+              }
+            }
+          }
+        },
+        ScalaDuration.Inf
+      )
     } finally executor.shutdown()
   }
 

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
@@ -2,6 +2,19 @@ package me.seroperson.reload.live
 
 class LiveReloadSpec extends LiveReloadBase {
 
+  testEach("http4s-slow-start - concurrent first requests wait for startup") {
+    sbtVersion =>
+      withRunner("http4s-slow-start", sbtVersion) { (runner, proxyPort) =>
+        runner.run("bgRun")
+        verifyHttpConcurrent(
+          Seq("greet", "greet2"),
+          200,
+          Some("hello"),
+          proxyPort
+        )
+      }
+  }
+
   testEach("http4s - live reload on source change") { sbtVersion =>
     withRunner("http4s", sbtVersion) { (runner, proxyPort) =>
       runner.run("bgRun")


### PR DESCRIPTION
## Summary

When two HTTP requests hit the proxy during first startup or reload, one request could run `buildLink.reload()`, start the app, and block in `RestApiHealthCheckStartupHook` while a concurrent request also called `reload()`, received `null` from the build link (classpath already updated), skipped startup waiting, and proxied to a target that was not listening yet — returning **503**.

`BaseDevServerStart.reload()` is now synchronized end-to-end on the same monitor as `startInternal()` / `stopInternal()`, so concurrent requests block until the in-progress startup or reload (including startup hooks) completes before they can observe “no change” and proxy.

Fixes [#25](https://github.com/seroperson/jvm-live-reload/issues/25).

## Changes

- `BaseDevServerStart.reload()` — `synchronized` so the full flow from `buildLink.reload()` through `stopInternal()` / `startInternal()` (startup hooks included) is serialized.
- New sbt scripted fixture `http4s-slow-start`: app delays binding for 2s; `RestApiHealthCheckStartupHook` is exercised via the default http4s hook bundle.
- `LiveReloadBase.verifyHttpConcurrent` — fires parallel GETs against the proxy.
- New sbt test: `http4s-slow-start - concurrent first requests wait for startup`.

## How was it tested?

- New sbt test: `http4s-slow-start - concurrent first requests wait for startup` in `LiveReloadSpec`
- Local verification (issue reproduction steps):

```sh
export JDK_JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
just publish-local-sbt
just test-sbt  # or targeted run for http4s-slow-start
```

Before the fix, two concurrent requests during first startup could yield one **503** (`Connection refused` to the target) and one **200**. After the fix, both wait for the same startup lifecycle and return **200**.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [x] No unrelated files were reformatted or refactored

