### PR TITLE
fix: HTTP dev server leaks XnioWorker threads

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
@@ -145,6 +145,7 @@ public abstract class BaseDevServerStart<S> implements ReloadableServer {
   /** Stops the currently running application instance. */
   protected synchronized void stopInternal() {
     if (appThread == null && classLoader == null) {
+      cleanupServerForOldGeneration();
       return;
     }
 
@@ -253,9 +254,7 @@ public abstract class BaseDevServerStart<S> implements ReloadableServer {
     if (isRunning.get()) {
       logger.info("🛑 Stopping the application");
       stopProxyServer();
-      if (appThread != null) {
-        stopInternal();
-      }
+      stopInternal();
       buildLink.close();
       isRunning.set(false);
       logger.debug("Application and proxy server were successfully stopped");

--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
@@ -7,6 +7,7 @@ import io.undertow.server.handlers.proxy.ProxyHandler;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import me.seroperson.reload.live.BaseDevServerStart;
 import me.seroperson.reload.live.UnrecoverableException;
 import me.seroperson.reload.live.build.BuildLink;
@@ -88,11 +89,7 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
         // start() failed after the worker was created. Release its threads, and
         // null out the field so cleanupServerForOldGeneration() does not later try
         // to shutdownNow() on an already-shutdown worker.
-        try {
-          workerToCleanup.shutdownNow();
-        } catch (Throwable shutdownErr) {
-          logger.error("Failed to shutdown XnioWorker after start() failure", shutdownErr);
-        }
+        shutdownWorker(workerToCleanup);
         this.currentGenerationWorker = null;
       }
       if (proxyToCleanup != null) {
@@ -117,9 +114,10 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
 
   @Override
   protected void cleanupServerForOldGeneration() {
-    if (currentGenerationWorker != null) {
-      currentGenerationWorker.shutdownNow();
+    var worker = currentGenerationWorker;
+    if (worker != null) {
       currentGenerationWorker = null;
+      shutdownWorker(worker);
     }
   }
 
@@ -155,6 +153,20 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
     } catch (IOException e) {
       throw new UnrecoverableException(
           "Failed to create XnioWorker for the HTTP proxy listener", e);
+    }
+  }
+
+  private void shutdownWorker(XnioWorker worker) {
+    try {
+      worker.shutdownNow();
+      if (!worker.awaitTermination(5, TimeUnit.SECONDS)) {
+        logger.warn("XnioWorker did not terminate within 5 seconds");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      logger.error("Interrupted while waiting for XnioWorker termination", e);
+    } catch (Throwable shutdownErr) {
+      logger.error("Failed to shutdown XnioWorker", shutdownErr);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixed an HTTP dev server shutdown leak where `XnioWorker` non-daemon threads stayed alive when the live-reload server was stopped before the first request.
## Related Issue
Fixed: #39 
## Change Type
- [x] Bug fix
- [x] Resource cleanup / lifecycle fix
- [x] Reliability improvement
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation only

## Real Behavior Proof
Before the fix:

```text
--- non-daemon threads after close before first request ---
XNIO-1 Accept state=RUNNABLE
XNIO-1 I/O-1 state=RUNNABLE
...
exit_code=124
```

After the fix:

```text
--- non-daemon threads after close before first request ---
main state=RUNNABLE
exit_code=0
```

Normal HTTP proxy flow was also validated:

```text
response=hello
closed=false
--- non-daemon threads after normal close ---
main state=RUNNABLE
exit_code=0
```

## Validation

- [x] Reproduced the original thread leak locally
- [x] Fixed the shutdown lifecycle path
- [x] Verified stop-before-first-request no longer leaks XNIO threads
- [x] Verified normal first-request proxy flow still works
- [x] Ran targeted Gradle checks
- [x] Ran formatting checks
- [x] Ran Gradle Ktor functional test

## Checklist

- [x] Code builds successfully
- [x] Formatting passes
- [x] Bug is reproduced before fix
- [x] Bug is fixed and validated after change
- [x] Normal HTTP live-reload behavior still works
- [x] No unrelated code changes included