### PR TITLE
fix:  HTTP proxy no longer forwards the proxy listener `Host` header to the target application

### DIFF
--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
@@ -61,7 +61,7 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
               proxyClientProvider,
               /* maxRequestTime */ -1,
               ResponseCodeHandler.HANDLE_404,
-              /* rewriteHostHeader */ false,
+              /* rewriteHostHeader */ true,
               /* reuseXForwarded */ false,
               2);
       // @formatter:on


### PR DESCRIPTION
## Summary
The Undertow HTTP proxy now rewrites the `Host` header for proxied requests so host-sensitive target applications receive the configured target host/port, for example `localhost:8081`, instead of the proxy address, for example `localhost:9000`.
## Related Issue
Closes #43
## Change Type
- [x] Bug fix
- [x] Regression test
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
## Real Behavior Proof
Before the fix, the target application could receive the proxy host header:

```text
Host: localhost:9000
```
After the fix, the target application receives the target host header:
```text
Requesting http://127.0.0.1:9000/host-check, got 200 and target saw Host=localhost:8081
BUILD SUCCESSFUL
```
## Checklist

- [x] Analyzed the HTTP proxy implementation.
- [x] Fixed the proxy `Host` header behavior.
- [x] Added a functional regression test.
- [x] Verified the target app receives `Host=localhost:8081`.
- [x] Ran focused core checks.
- [x] Ran the new functional test with `--rerun-tasks`.
- [x] Ran formatting checks.