### PR TITLE
fix: add startup timeout to health-check hooks so reload aborts inste…

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ First, let's check the list of available options:
 | `live.reload.grpc.proxy.tls.key`    | `LIVE_RELOAD_GRPC_PROXY_TLS_KEY`    | `""`        | Path to a PEM-encoded private key used by the proxy listener (when both this and the cert are set, the proxy listens with TLS instead of plaintext) |
 | `live.reload.debug`                 | `LIVE_RELOAD_DEBUG`                 | `false`     | Whether to enable/disable debug output                                                                                                              |
 | `live.reload.thread.interrupt.timeout` | `LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT` | `15000`  | How long (ms) `ThreadInterruptShutdownHook` waits for the application's main thread to exit after `Thread.interrupt()`. If it doesn't, the reload aborts with an unrecoverable error rather than continuing with a stale thread. |
+| `live.reload.startup.timeout`       | `LIVE_RELOAD_STARTUP_TIMEOUT`       | `60000`     | How long (ms) a health-check startup hook waits for the application to report ready. If it stays alive but never becomes healthy (e.g. keeps returning `503` or refusing connections), the reload aborts with an unrecoverable error instead of polling forever and wedging the dev server. Set to `0` to wait indefinitely. |
 
 To change variables using build configuration, use the following key for `sbt`:
 

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/GrpcHealthCheckStartupHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/GrpcHealthCheckStartupHook.java
@@ -25,11 +25,23 @@ public class GrpcHealthCheckStartupHook implements GrpcHealthCheckHook {
 
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    var service = settings.getGrpcHealthService();
+    long timeout = settings.getStartupTimeoutMs();
+    long deadline = System.currentTimeMillis() + timeout;
     try {
       while (true) {
         AppFailureRegistry.throwIfFailed(th);
+        if (timeout > 0 && System.currentTimeMillis() >= deadline) {
+          throw new UnrecoverableException(
+              "GRPC health-check service "
+                  + service
+                  + " did not become available within "
+                  + timeout
+                  + "ms. Configure '"
+                  + DevServerSettings.LiveReloadStartupTimeout
+                  + "' to adjust the timeout (0 disables it).");
+        }
         logger.debug("Waiting for the GRPC health-check to return success ...");
-        var service = settings.getGrpcHealthService();
         var healthResponse =
             isHealthy(logger, service, settings.getGrpcHost(), settings.getGrpcPort());
         if (healthResponse == 1) {

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckStartupHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckStartupHook.java
@@ -25,11 +25,23 @@ public abstract class HealthCheckStartupHook implements HealthCheckHook {
 
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    var path = settings.getHealthCheckPath();
+    long timeout = settings.getStartupTimeoutMs();
+    long deadline = System.currentTimeMillis() + timeout;
     try {
       while (true) {
         AppFailureRegistry.throwIfFailed(th);
+        if (timeout > 0 && System.currentTimeMillis() >= deadline) {
+          throw new UnrecoverableException(
+              "Health-check at "
+                  + path
+                  + " did not become ready within "
+                  + timeout
+                  + "ms. Configure '"
+                  + DevServerSettings.LiveReloadStartupTimeout
+                  + "' to adjust the timeout (0 disables it).");
+        }
         logger.debug("Waiting for the health-check to return success ...");
-        var path = settings.getHealthCheckPath();
         var healthResponse =
             isHealthy(logger, path, settings.getHttpHost(), settings.getHttpPort());
         if (healthResponse == 1) {

--- a/core/build-link/src/main/java/me/seroperson/reload/live/settings/DevServerSettings.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/settings/DevServerSettings.java
@@ -38,6 +38,7 @@ public final class DevServerSettings {
   public static final String LiveReloadIsDebug = "live.reload.debug";
   public static final String LiveReloadThreadInterruptTimeout =
       "live.reload.thread.interrupt.timeout";
+  public static final String LiveReloadStartupTimeout = "live.reload.startup.timeout";
 
   private final Map<String, String> javaOptionProperties;
   private final Map<String, String> argsProperties;
@@ -86,6 +87,14 @@ public final class DevServerSettings {
           LiveReloadThreadInterruptTimeout,
           "LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT",
           15000L,
+          String::valueOf,
+          Long::parseLong);
+
+  private final DevParameter<Long> startupTimeoutMs =
+      new DevParameter<>(
+          LiveReloadStartupTimeout,
+          "LIVE_RELOAD_STARTUP_TIMEOUT",
+          60000L,
           String::valueOf,
           Long::parseLong);
 
@@ -198,6 +207,7 @@ public final class DevServerSettings {
     grpcProxyTlsKey.putInto(merged);
     debug.putInto(merged);
     threadInterruptTimeoutMs.putInto(merged);
+    startupTimeoutMs.putInto(merged);
     return merged;
   }
 
@@ -265,6 +275,21 @@ public final class DevServerSettings {
    */
   public Long getThreadInterruptTimeoutMs() {
     return threadInterruptTimeoutMs.getValueOrDefault(
+        javaOptionProperties, argsProperties, pluginSettings);
+  }
+
+  /**
+   * Maximum time, in milliseconds, that a health-check startup hook will wait for the application to
+   * report ready before giving up. If the application stays alive but never becomes healthy (e.g.
+   * keeps returning {@code 503} or refusing connections), the hook throws an {@code
+   * UnrecoverableException} when this deadline elapses so the proxy tears the reload down instead of
+   * polling forever and wedging the dev server. A value of {@code 0} disables the timeout (unbounded
+   * wait).
+   *
+   * @return startup readiness timeout in ms (default: 60000, 0 = unbounded)
+   */
+  public Long getStartupTimeoutMs() {
+    return startupTimeoutMs.getValueOrDefault(
         javaOptionProperties, argsProperties, pluginSettings);
   }
 

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckStartupHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckStartupHook.java
@@ -26,9 +26,21 @@ public class GrpcHealthCheckStartupHook implements GrpcHealthCheckHook {
 
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    long timeout = settings.getStartupTimeoutMs();
+    long deadline = System.currentTimeMillis() + timeout;
     try {
       while (true) {
         AppFailureRegistry.throwIfFailed(th);
+        if (timeout > 0 && System.currentTimeMillis() >= deadline) {
+          throw new UnrecoverableException(
+              "GRPC health-check service '"
+                  + settings.getGrpcHealthService()
+                  + "' did not report SERVING within "
+                  + timeout
+                  + "ms. Configure '"
+                  + DevServerSettings.LiveReloadStartupTimeout
+                  + "' to adjust the timeout (0 disables it).");
+        }
         logger.debug("Waiting for the GRPC health-check to return SERVING ...");
         var response = isHealthy(logger, settings);
         if (response == 1) {


### PR DESCRIPTION
## Summary

Health-check startup hooks polled `isHealthy(...)` in an unbounded `while (true)` loop. If the application stayed alive but never became healthy (e.g. kept returning `503` or refusing connections), the hook spun forever — wedging the proxy and making the dev server impossible to stop. This adds a configurable `live.reload.startup.timeout` (default `60000`ms): once the deadline elapses the hook throws an `UnrecoverableException` so the proxy tears the reload down instead of polling forever. Set it to `0` to keep the old unbounded behavior.

Fixes #45

## How was it tested?

- Manual test against a real build: started an app whose health check never reports ready and confirmed the reload now aborts with the `UnrecoverableException` (and the descriptive timeout message) after the configured timeout, rather than hanging. Verified `live.reload.startup.timeout=0` restores the unbounded wait.

## Checklist

- [ ] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [ ] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support (n/a — no framework added)
- [x] No unrelated files were reformatted or refactored
