### PR TITLE
fix(runner): don't leak env vars and shutdown hooks when start() fails

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
@@ -63,6 +63,7 @@ public final class DevServerRunner {
     var buildLoader = this.getClass().getClassLoader();
     var rootClassLoader = ClassLoader.getSystemClassLoader().getParent();
 
+    DevServerWrapper wrapper = null;
     try {
       var sharedClasses =
           List.of(
@@ -105,11 +106,19 @@ public final class DevServerRunner {
                   params.getInternalMainClassName(),
                   params.getStartupHookClasses(),
                   params.getShutdownHookClasses());
-      var wrapper = new DevServerWrapper(params, logger, server);
+      wrapper = new DevServerWrapper(params, logger, server);
       wrapper.start();
       return wrapper;
     } catch (Throwable e) {
       logger.error("Error during proxy server initialization", e);
+      if (wrapper != null) {
+        try {
+          wrapper.close();
+          logger.info("Restored build process state after failed start()");
+        } catch (Throwable closeErr) {
+          e.addSuppressed(closeErr);
+        }
+      }
       throw new RuntimeException(e);
     }
   }

--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerWrapper.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerWrapper.java
@@ -31,13 +31,15 @@ public class DevServerWrapper implements ReloadableServer {
 
   @Override
   public void start() {
+    // Capture every snapshot before mutating anything, so close() can roll back
+    // even if a later step (putEnv, unregisterShutdownHooks, server.start) throws.
     this.initialEnv = new HashMap<>(System.getenv());
-    var propagateEnv = params.getPropagateEnv();
-    Environment.putEnv(propagateEnv);
-
     this.buildSystemShutdownHooks = new IdentityHashMap<>(ShutdownHook.getRegistredShutdownHooks());
     this.buildSystemHookThreadIds =
         buildSystemShutdownHooks.keySet().stream().map(Thread::getId).collect(Collectors.toSet());
+
+    Environment.putEnv(params.getPropagateEnv());
+
     logger.debug("Preserving shutdown hooks:");
     ShutdownHook.logShutdownHooks(buildSystemShutdownHooks, logger);
     ShutdownHook.unregisterShutdownHooks(buildSystemHookThreadIds);
@@ -70,8 +72,12 @@ public class DevServerWrapper implements ReloadableServer {
     try {
       server.close();
     } finally {
-      Environment.setEnv(initialEnv);
-      ShutdownHook.setShutdownHooks(new IdentityHashMap<>(buildSystemShutdownHooks));
+      if (initialEnv != null) {
+        Environment.setEnv(initialEnv);
+      }
+      if (buildSystemShutdownHooks != null) {
+        ShutdownHook.setShutdownHooks(new IdentityHashMap<>(buildSystemShutdownHooks));
+      }
     }
   }
 }

--- a/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
+++ b/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
@@ -33,10 +33,6 @@ livePropagateEnv := Map(
   "JLR_LEAK_CHECK" -> "leaked"
 )
 
-// Fails when JLR_LEAK_CHECK is still present in the sbt JVM's own process
-// environment, so a leaked env shows up as a task failure rather than as
-// a log line. System.getenv reads the same ProcessEnvironment map that
-// Environment.putEnv/setEnv mutate, so the leak is observable here.
 val assertEnvRolledBack =
   taskKey[Unit]("Fails if JLR_LEAK_CHECK is present in the sbt JVM environment")
 assertEnvRolledBack := {

--- a/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
+++ b/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
@@ -33,5 +33,17 @@ livePropagateEnv := Map(
   "JLR_LEAK_CHECK" -> "leaked"
 )
 
+// Dumps the live state of the sbt JVM's own process environment. After a
+// failed bgRun, the test runs this and asserts JLR_LEAK_CHECK is absent,
+// proving the propagated env was actually rolled back (not just that a log
+// line was printed). System.getenv reads the same ProcessEnvironment map
+// that Environment.putEnv/setEnv mutate, so the leak is observable here.
+val dumpLeakCheckEnv =
+  taskKey[Unit]("Logs whether JLR_LEAK_CHECK is present in the sbt JVM environment")
+dumpLeakCheckEnv := {
+  val value = Option(System.getenv("JLR_LEAK_CHECK")).getOrElse("<absent>")
+  streams.value.log.info(s"JLR_LEAK_CHECK_ENV=$value")
+}
+
 buildInfoKeys := Seq[BuildInfoKey](port)
 buildInfoPackage := "me.seroperson"

--- a/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
+++ b/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
@@ -1,0 +1,37 @@
+val Http4sVersion = "0.23.30"
+
+enablePlugins(LiveReloadPlugin)
+enablePlugins(BuildInfoPlugin)
+
+scalaVersion := "2.13.16"
+resolvers += Resolver.mavenLocal
+libraryDependencies ++= Seq(
+  "org.http4s" %% "http4s-ember-server" % Http4sVersion,
+  "org.http4s" %% "http4s-dsl" % Http4sVersion,
+  "org.typelevel" %% "cats-effect" % "3.6.3"
+)
+
+val isSbt2 = settingKey[Boolean]("isSbt2")
+isSbt2 := (sbtBinaryVersion.value match {
+  case "2" => true
+  case _   => false
+})
+
+val proxyPort = settingKey[Int]("proxyPort")
+proxyPort := sys.props.get("testkit.proxyPort").map(_.toInt).getOrElse(if (isSbt2.value) 9001 else 9000)
+
+val port = settingKey[Int]("port")
+port := sys.props.get("testkit.port").map(_.toInt).getOrElse(if (isSbt2.value) 8081 else 8080)
+
+liveDevSettings := Seq(
+  DevSettingsKeys.LiveReloadProxyHttpPort -> proxyPort.value.toString,
+  DevSettingsKeys.LiveReloadHttpPort -> port.value.toString,
+  DevSettingsKeys.LiveReloadIsDebug -> "true"
+)
+
+livePropagateEnv := Map(
+  "JLR_LEAK_CHECK" -> "leaked"
+)
+
+buildInfoKeys := Seq[BuildInfoKey](port)
+buildInfoPackage := "me.seroperson"

--- a/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
+++ b/sbt/src/test/resources/http4s-propagate-env-rollback/build.sbt
@@ -33,16 +33,16 @@ livePropagateEnv := Map(
   "JLR_LEAK_CHECK" -> "leaked"
 )
 
-// Dumps the live state of the sbt JVM's own process environment. After a
-// failed bgRun, the test runs this and asserts JLR_LEAK_CHECK is absent,
-// proving the propagated env was actually rolled back (not just that a log
-// line was printed). System.getenv reads the same ProcessEnvironment map
-// that Environment.putEnv/setEnv mutate, so the leak is observable here.
-val dumpLeakCheckEnv =
-  taskKey[Unit]("Logs whether JLR_LEAK_CHECK is present in the sbt JVM environment")
-dumpLeakCheckEnv := {
-  val value = Option(System.getenv("JLR_LEAK_CHECK")).getOrElse("<absent>")
-  streams.value.log.info(s"JLR_LEAK_CHECK_ENV=$value")
+// Fails when JLR_LEAK_CHECK is still present in the sbt JVM's own process
+// environment, so a leaked env shows up as a task failure rather than as
+// a log line. System.getenv reads the same ProcessEnvironment map that
+// Environment.putEnv/setEnv mutate, so the leak is observable here.
+val assertEnvRolledBack =
+  taskKey[Unit]("Fails if JLR_LEAK_CHECK is present in the sbt JVM environment")
+assertEnvRolledBack := {
+  Option(System.getenv("JLR_LEAK_CHECK")).foreach { value =>
+    sys.error(s"JLR_LEAK_CHECK leaked into the sbt JVM environment: $value")
+  }
 }
 
 buildInfoKeys := Seq[BuildInfoKey](port)

--- a/sbt/src/test/resources/http4s-propagate-env-rollback/project/plugins.sbt
+++ b/sbt/src/test/resources/http4s-propagate-env-rollback/project/plugins.sbt
@@ -1,0 +1,6 @@
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
+resolvers += Resolver.mavenLocal
+
+addSbtPlugin("me.seroperson" % "sbt-live-reload" % sys.props("project.version"))
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")

--- a/sbt/src/test/resources/http4s-propagate-env-rollback/src/main/scala/App.scala
+++ b/sbt/src/test/resources/http4s-propagate-env-rollback/src/main/scala/App.scala
@@ -1,0 +1,38 @@
+import cats.effect.Async
+import cats.effect.IO
+import cats.effect.IOApp
+import cats.effect.Sync
+import cats.syntax.all._
+import com.comcast.ip4s._
+import org.http4s._
+import org.http4s.dsl.Http4sDsl
+import org.http4s.dsl.io._
+import org.http4s.ember.server.EmberServerBuilder
+import org.http4s.implicits._
+
+object App extends IOApp.Simple {
+
+  def helloWorldRoutes: HttpRoutes[IO] = {
+    val dsl = new Http4sDsl[IO] {}
+    import dsl._
+    HttpRoutes.of[IO] {
+      case GET -> Root / "greet" =>
+        Ok(sys.env.getOrElse("JLR_LEAK_CHECK", "<absent>"))
+      case GET -> Root / "health" =>
+        Ok()
+    }
+  }
+
+  def runServer: IO[Nothing] = {
+    for {
+      _ <-
+        EmberServerBuilder
+          .default[IO]
+          .withPort(Port.fromInt(me.seroperson.BuildInfo.port).get)
+          .withHttpApp(helloWorldRoutes.orNotFound)
+          .build
+    } yield ()
+  }.useForever
+
+  val run = runServer
+}

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
@@ -181,22 +181,22 @@ class LiveReloadSpec extends LiveReloadBase {
           blocker.bind(new InetSocketAddress("localhost", proxyPort))
           val result = runner.run("bgRun")
           val logs = result.logs.mkString("\n")
-          // The error log proves start() reached server.start() and threw,
-          // i.e. it ran past Environment.putEnv - the env table was actually
-          // mutated, so this is a real leak window, not a no-op.
+          // The held port makes server.start() throw after start() has
+          // already run past Environment.putEnv, so the failed bgRun is
+          // a real leak window, not a no-op.
           assert(
-            result.logsContain("Error during proxy server initialization"),
-            s"expected runBackground catch to fire, got logs:\n$logs"
+            !result.succeeded,
+            s"expected bgRun to fail while the proxy port is held, got logs:\n$logs"
           )
-          // Directly observe the sbt JVM's own environment after the failed
-          // start. dumpLeakCheckEnv reads System.getenv in the same JVM that
-          // ran bgRun; if the rollback failed, JLR_LEAK_CHECK would still be
-          // "leaked" here. Absence proves wrapper.close() restored the env.
-          val dump = runner.run("dumpLeakCheckEnv")
-          val dumpLogs = dump.logs.mkString("\n")
+          // assertEnvRolledBack reads System.getenv in the same JVM that
+          // ran bgRun and fails if JLR_LEAK_CHECK is still set, so task
+          // success is strict evidence that wrapper.close() restored the
+          // env after the failed start.
+          val check = runner.run("assertEnvRolledBack")
+          val checkLogs = check.logs.mkString("\n")
           assert(
-            dump.logsContain("JLR_LEAK_CHECK_ENV=<absent>"),
-            s"expected JLR_LEAK_CHECK to be rolled back out of the sbt env, got logs:\n$dumpLogs"
+            check.succeeded,
+            s"expected JLR_LEAK_CHECK to be rolled back out of the sbt env, got logs:\n$checkLogs"
           )
         } finally blocker.close()
     }

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
@@ -181,19 +181,22 @@ class LiveReloadSpec extends LiveReloadBase {
           blocker.bind(new InetSocketAddress("localhost", proxyPort))
           val result = runner.run("bgRun")
           val logs = result.logs.mkString("\n")
-          // The error log proves the catch fired.
+          // The error log proves start() reached server.start() and threw,
+          // i.e. it ran past Environment.putEnv - the env table was actually
+          // mutated, so this is a real leak window, not a no-op.
           assert(
             result.logsContain("Error during proxy server initialization"),
             s"expected runBackground catch to fire, got logs:\n$logs"
           )
-          // The restored-state log is emitted only after wrapper.close()
-          // returns without throwing, so its presence proves the
-          // rollback ran end-to-end.
+          // Directly observe the sbt JVM's own environment after the failed
+          // start. dumpLeakCheckEnv reads System.getenv in the same JVM that
+          // ran bgRun; if the rollback failed, JLR_LEAK_CHECK would still be
+          // "leaked" here. Absence proves wrapper.close() restored the env.
+          val dump = runner.run("dumpLeakCheckEnv")
+          val dumpLogs = dump.logs.mkString("\n")
           assert(
-            result.logsContain(
-              "Restored build process state after failed start()"
-            ),
-            s"expected rollback to complete, got logs:\n$logs"
+            dump.logsContain("JLR_LEAK_CHECK_ENV=<absent>"),
+            s"expected JLR_LEAK_CHECK to be rolled back out of the sbt env, got logs:\n$dumpLogs"
           )
         } finally blocker.close()
     }

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
@@ -171,27 +171,17 @@ class LiveReloadSpec extends LiveReloadBase {
   ) { sbtVersion =>
     withRunner("http4s-propagate-env-rollback", sbtVersion) {
       (runner, proxyPort) =>
-        // Hold the proxy port from the test JVM so the sbt JVM's
-        // proxy server.start() throws BindException. runBackground's
-        // catch must call wrapper.close() to restore the env table
-        // and shutdown hooks in the sbt JVM.
         val blocker = new ServerSocket()
         blocker.setReuseAddress(true)
         try {
           blocker.bind(new InetSocketAddress("localhost", proxyPort))
           val result = runner.run("bgRun")
           val logs = result.logs.mkString("\n")
-          // The held port makes server.start() throw after start() has
-          // already run past Environment.putEnv, so the failed bgRun is
-          // a real leak window, not a no-op.
           assert(
             !result.succeeded,
             s"expected bgRun to fail while the proxy port is held, got logs:\n$logs"
           )
-          // assertEnvRolledBack reads System.getenv in the same JVM that
-          // ran bgRun and fails if JLR_LEAK_CHECK is still set, so task
-          // success is strict evidence that wrapper.close() restored the
-          // env after the failed start.
+
           val check = runner.run("assertEnvRolledBack")
           val checkLogs = check.logs.mkString("\n")
           assert(

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
@@ -1,5 +1,8 @@
 package me.seroperson.reload.live
 
+import java.net.InetSocketAddress
+import java.net.ServerSocket
+
 class LiveReloadSpec extends LiveReloadBase {
 
   testEach("http4s-slow-start - concurrent first requests wait for startup") {
@@ -159,6 +162,40 @@ class LiveReloadSpec extends LiveReloadBase {
       )
       verifyHttp("greet", 503, Some("dev server stopped"), proxyPort)
       verifyPortClosed(proxyPort)
+    }
+  }
+
+  testEach(
+    "http4s - propagated env is rolled back when proxy fails to bind",
+    Seq("2.0.0-RC10")
+  ) { sbtVersion =>
+    withRunner("http4s-propagate-env-rollback", sbtVersion) {
+      (runner, proxyPort) =>
+        // Hold the proxy port from the test JVM so the sbt JVM's
+        // proxy server.start() throws BindException. runBackground's
+        // catch must call wrapper.close() to restore the env table
+        // and shutdown hooks in the sbt JVM.
+        val blocker = new ServerSocket()
+        blocker.setReuseAddress(true)
+        try {
+          blocker.bind(new InetSocketAddress("localhost", proxyPort))
+          val result = runner.run("bgRun")
+          val logs = result.logs.mkString("\n")
+          // The error log proves the catch fired.
+          assert(
+            result.logsContain("Error during proxy server initialization"),
+            s"expected runBackground catch to fire, got logs:\n$logs"
+          )
+          // The restored-state log is emitted only after wrapper.close()
+          // returns without throwing, so its presence proves the
+          // rollback ran end-to-end.
+          assert(
+            result.logsContain(
+              "Restored build process state after failed start()"
+            ),
+            s"expected rollback to complete, got logs:\n$logs"
+          )
+        } finally blocker.close()
     }
   }
 }


### PR DESCRIPTION
## Summary

When `DevServerWrapper.start()` got past `Environment.putEnv` and then `server.start()` threw, the restore path in `close()` was never reached. The build process (sbt REPL, Gradle daemon, mill worker) was left with `livePropagateEnv` permanently merged into its environment and the build system's shutdown hooks gone. `DevServerRunner.runBackground` also lost the `wrapper` reference inside its `try` block, so nothing else could call `close()` either — and a retry then snapshotted the corrupted state as the new "initial", making the leak permanent for the session.

## Root cause

`DevServerWrapper.start()` (`core/runner/.../DevServerWrapper.java`) captured `initialEnv`, then **mutated** the env via `Environment.putEnv(...)`, **then** captured `buildSystemShutdownHooks`. If anything between the env capture and the shutdown-hook capture threw, `buildSystemShutdownHooks` was `null` and `close()`'s restore branch NPE'd. `DevServerRunner.runBackground` declared `var wrapper = new DevServerWrapper(...)` inside the `try`, so on `wrapper.start()` failure the catch had no reference to call `wrapper.close()`.

Real-world trigger: any user whose `live.reload.proxy.http.port` is already bound (a stale dev process, another listener on the same port). The proxy fails to bind, the build process's env table now has the propagated keys, and no further reload attempt clears them.

## Fix

Three coordinated edits, no new public surface:

- **`DevServerWrapper.start()`** — capture all three snapshots (env, shutdown hooks, hook thread ids) **before** any mutation. `close()` can now roll back even on a partial `start()`.
- **`DevServerWrapper.close()`** — null-guard the restore branches so it is safe on a never-started or partially-started wrapper.
- **`DevServerRunner.runBackground`** — hoist `wrapper` out of the `try` and call `wrapper.close()` in the catch, with the close exception suppressed onto the original throwable. Log one `info` line after a successful rollback so the user sees that the dev server cleaned up.

Diff: **+154 / −6** across 6 files (3 source files + 3 new sbt scripted-fixture files).

Fixes [#11](https://github.com/seroperson/jvm-live-reload/issues/11).

## How was it tested?

- New sbt test: `http4s - propagated env is rolled back when proxy fails to bind` in `LiveReloadSpec` (sbt 2.x). The test holds the proxy port from the test JVM so `server.start()` throws `BindException`, asserts that `bgRun` itself failed, then runs the fixture's `assertEnvRolledBack` task, which fails when `JLR_LEAK_CHECK` is still present in the sbt JVM environment, and asserts it succeeded. **Both checks are strict asserts on `TaskResult.succeeded`, not log scans** — so a leaked env surfaces as a task failure.
- Local verification (Linux, JDK 17):

```sh
export JDK_JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
sbt quickLocalPublish
sbt 'sbtLiveReload/Test/testOnly me.seroperson.reload.live.LiveReloadSpec'   # 25 / 25 passed, 12m45s
scala-cli fmt --check                                                         # clean
./gradlew :gradle:spotlessCheck                                                # BUILD SUCCESSFUL
```

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
