### PR TITLE
feat: add background compile on file change to speed up reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ First, let's check the list of available options:
 | `live.reload.grpc.proxy.tls.key`    | `LIVE_RELOAD_GRPC_PROXY_TLS_KEY`    | `""`        | Path to a PEM-encoded private key used by the proxy listener (when both this and the cert are set, the proxy listens with TLS instead of plaintext) |
 | `live.reload.debug`                 | `LIVE_RELOAD_DEBUG`                 | `false`     | Whether to enable/disable debug output                                                                                                              |
 | `live.reload.thread.interrupt.timeout` | `LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT` | `15000`  | How long (ms) `ThreadInterruptShutdownHook` waits for the application's main thread to exit after `Thread.interrupt()`. If it doesn't, the reload aborts with an unrecoverable error rather than continuing with a stale thread. |
+| `live.reload.compile.on.change`      | `LIVE_RELOAD_COMPILE_ON_CHANGE`      | `true`      | When enabled, starts compilation in the background after source files change (debounced), so the next reload request can skip waiting on compile. |
+| `live.reload.compile.debounce.ms`    | `LIVE_RELOAD_COMPILE_DEBOUNCE_MS`    | `300`       | Milliseconds to wait after the last detected file change before starting a background compile. |
 
 To change variables using build configuration, use the following key for `sbt`:
 

--- a/core/build-link/src/main/java/me/seroperson/reload/live/settings/DevServerSettings.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/settings/DevServerSettings.java
@@ -38,6 +38,8 @@ public final class DevServerSettings {
   public static final String LiveReloadIsDebug = "live.reload.debug";
   public static final String LiveReloadThreadInterruptTimeout =
       "live.reload.thread.interrupt.timeout";
+  public static final String LiveReloadCompileOnChange = "live.reload.compile.on.change";
+  public static final String LiveReloadCompileDebounceMs = "live.reload.compile.debounce.ms";
 
   private final Map<String, String> javaOptionProperties;
   private final Map<String, String> argsProperties;
@@ -86,6 +88,22 @@ public final class DevServerSettings {
           LiveReloadThreadInterruptTimeout,
           "LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT",
           15000L,
+          String::valueOf,
+          Long::parseLong);
+
+  private final DevParameter<Boolean> compileOnChange =
+      new DevParameter<>(
+          LiveReloadCompileOnChange,
+          "LIVE_RELOAD_COMPILE_ON_CHANGE",
+          true,
+          String::valueOf,
+          Boolean::parseBoolean);
+
+  private final DevParameter<Long> compileDebounceMs =
+      new DevParameter<>(
+          LiveReloadCompileDebounceMs,
+          "LIVE_RELOAD_COMPILE_DEBOUNCE_MS",
+          300L,
           String::valueOf,
           Long::parseLong);
 
@@ -198,6 +216,8 @@ public final class DevServerSettings {
     grpcProxyTlsKey.putInto(merged);
     debug.putInto(merged);
     threadInterruptTimeoutMs.putInto(merged);
+    compileOnChange.putInto(merged);
+    compileDebounceMs.putInto(merged);
     return merged;
   }
 
@@ -266,6 +286,25 @@ public final class DevServerSettings {
   public Long getThreadInterruptTimeoutMs() {
     return threadInterruptTimeoutMs.getValueOrDefault(
         javaOptionProperties, argsProperties, pluginSettings);
+  }
+
+  /**
+   * Whether to compile in the background when source files change, before the next reload request.
+   *
+   * @return true to prefetch compilation on change (default: true)
+   */
+  public boolean isCompileOnChange() {
+    return compileOnChange.getValueOrDefault(javaOptionProperties, argsProperties, pluginSettings);
+  }
+
+  /**
+   * Debounce interval in milliseconds before starting a background compile after the last file
+   * change.
+   *
+   * @return debounce delay in ms (default: 300)
+   */
+  public long getCompileDebounceMs() {
+    return compileDebounceMs.getValueOrDefault(javaOptionProperties, argsProperties, pluginSettings);
   }
 
   /**

--- a/core/runner/build.gradle.kts
+++ b/core/runner/build.gradle.kts
@@ -6,6 +6,11 @@ dependencies {
     api(project(":core:build-link"))
     api("org.playframework:play-file-watch:3.0.0-M4")
     implementation("org.jline:jline:3.30.6")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.11.4")
+}
+
+tasks.test {
+    useJUnitPlatform()
 }
 
 publishing {

--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
@@ -12,6 +12,10 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
@@ -20,6 +24,7 @@ import me.seroperson.reload.live.build.BuildLink;
 import me.seroperson.reload.live.runner.CompileResult.CompileFailure;
 import me.seroperson.reload.live.runner.CompileResult.CompileSuccess;
 import me.seroperson.reload.live.runner.classloader.NamedURLClassLoader;
+import me.seroperson.reload.live.settings.DevServerSettings;
 import play.dev.filewatch.FileWatchService;
 import play.dev.filewatch.FileWatcher;
 
@@ -32,6 +37,12 @@ final class DevServerReloader implements BuildLink, Closeable {
   private final Supplier<Boolean> triggerReload;
 
   private final ClassLoader dependenciesClassLoader;
+
+  private final boolean compileOnChange;
+
+  private final long compileDebounceMs;
+
+  private final ScheduledExecutorService prefetchScheduler;
 
   // The current classloader for the application
   private volatile URLClassLoader currentApplicationClassLoader;
@@ -54,15 +65,35 @@ final class DevServerReloader implements BuildLink, Closeable {
 
   private final AtomicInteger classLoaderVersion = new AtomicInteger(0);
 
+  private volatile CompileResult prefetchedCompileResult;
+
+  private volatile boolean prefetchReady = false;
+
+  private volatile ScheduledFuture<?> pendingPrefetch;
+
   DevServerReloader(
       ClassLoader dependenciesClassLoader,
       Supplier<CompileResult> compile,
       Supplier<Boolean> triggerReload,
       List<File> monitoredFiles,
-      FileWatchService fileWatchService) {
+      FileWatchService fileWatchService,
+      DevServerSettings settings) {
     this.dependenciesClassLoader = dependenciesClassLoader;
     this.compile = compile;
     this.triggerReload = triggerReload;
+    this.compileOnChange = settings.isCompileOnChange();
+    this.compileDebounceMs = settings.getCompileDebounceMs();
+    if (compileOnChange) {
+      prefetchScheduler =
+          Executors.newSingleThreadScheduledExecutor(
+              r -> {
+                Thread thread = new Thread(r, "jvm-live-reload-prefetch");
+                thread.setDaemon(true);
+                return thread;
+              });
+    } else {
+      prefetchScheduler = null;
+    }
     if (!monitoredFiles.isEmpty() && fileWatchService != null) {
       // Create the watcher, updates the changed boolean when a file has changed:
       this.watcher =
@@ -70,6 +101,7 @@ final class DevServerReloader implements BuildLink, Closeable {
               monitoredFiles,
               () -> {
                 changed = true;
+                scheduleBackgroundCompile();
                 return null;
               });
     } else {
@@ -96,9 +128,52 @@ final class DevServerReloader implements BuildLink, Closeable {
         accessControlContext);
   }
 
+  void scheduleBackgroundCompile() {
+    if (!compileOnChange || prefetchScheduler == null) {
+      return;
+    }
+    synchronized (this) {
+      prefetchReady = false;
+      prefetchedCompileResult = null;
+      if (pendingPrefetch != null) {
+        pendingPrefetch.cancel(false);
+      }
+      pendingPrefetch =
+          prefetchScheduler.schedule(
+              this::runBackgroundCompile, compileDebounceMs, TimeUnit.MILLISECONDS);
+    }
+  }
+
+  private void runBackgroundCompile() {
+    withReloaderContextClassLoader(
+        () -> {
+          CompileResult result = compile.get();
+          synchronized (DevServerReloader.this) {
+            prefetchedCompileResult = result;
+            prefetchReady = true;
+            pendingPrefetch = null;
+          }
+          return null;
+        });
+  }
+
+  private CompileResult resolveCompileResult() {
+    CompileResult prefetched = null;
+    synchronized (this) {
+      if (compileOnChange && prefetchReady && prefetchedCompileResult != null) {
+        prefetched = prefetchedCompileResult;
+        prefetchedCompileResult = null;
+        prefetchReady = false;
+      }
+    }
+    if (prefetched != null) {
+      return prefetched;
+    }
+    return withReloaderContextClassLoader(compile::get);
+  }
+
   private Object reload(boolean shouldReload) {
-    // Run the reload task, which will trigger everything to compile
-    CompileResult compileResult = compile.get();
+    CompileResult compileResult = resolveCompileResult();
     if (compileResult instanceof CompileFailure result) {
       // We force reload next time because compilation failed this time
       forceReloadNextTime = true;
@@ -123,46 +198,6 @@ final class DevServerReloader implements BuildLink, Closeable {
         currentApplicationClassLoader =
             new NamedURLClassLoader(
                 "iteration(" + iteration + ")", urls(cp), dependenciesClassLoader);
-
-        /*
-        @formatter:off
-        System.out.println("Got classpath: " + cp);
-        cp.stream().forEach((file) -> {
-          try {
-            var path = java.nio.file.Paths.get("/", "home", "seroperson", "out");
-            Files.list(file.toPath()).forEach((p) -> {
-              try {
-                System.out.println("Copying path: " + p + " to "
-                    + path.resolve(p.getFileName().toString() + "." + classLoaderVersion.get()));
-                Files.copy(p,
-                    path.resolve(p.getFileName().toString() + "." + classLoaderVersion.get()));
-              } catch (IOException e) {
-                e.printStackTrace();
-              }
-            });
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-        });
-        @formatter:on
-        */
-
-        /*
-        @formatter:off
-        System.out.println("Got classpath: " + cp);
-        cp.stream().forEach((file) -> {
-          try {
-            var path = java.nio.file.Paths.get("/", "home", "seroperson", "out");
-            System.out.println("Copying path: " + file.toPath() + " to " + path
-                .resolve(file.toPath().getFileName().toString() + "." + classLoaderVersion.get()));
-            Files.copy(file.toPath(), path
-                .resolve(file.toPath().getFileName().toString() + "." + classLoaderVersion.get()));
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-        });
-        @formatter:on
-        */
 
         return new ReloadGeneration(iteration, currentApplicationClassLoader);
       }
@@ -193,9 +228,7 @@ final class DevServerReloader implements BuildLink, Closeable {
       var shouldReload = forceReloadNextTime;
       changed = false;
       forceReloadNextTime = false;
-      // use Reloader context ClassLoader to avoid ClassLoader leaks in
-      // sbt/scala-compiler threads
-      return withReloaderContextClassLoader(() -> reload(shouldReload));
+      return reload(shouldReload);
     } else {
       return null; // null means nothing changed
     }
@@ -214,6 +247,21 @@ final class DevServerReloader implements BuildLink, Closeable {
 
   @Override
   public void close() {
+    if (prefetchScheduler != null) {
+      synchronized (this) {
+        if (pendingPrefetch != null) {
+          pendingPrefetch.cancel(false);
+          pendingPrefetch = null;
+        }
+      }
+      prefetchScheduler.shutdown();
+      try {
+        prefetchScheduler.awaitTermination(2, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        prefetchScheduler.shutdownNow();
+      }
+    }
     var cl = currentApplicationClassLoader;
     currentApplicationClassLoader = null;
     if (cl != null) {

--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
@@ -85,7 +85,8 @@ public final class DevServerRunner {
               reloadCompile,
               triggerReload,
               params.getMonitoredFiles(),
-              fileWatchService);
+              fileWatchService,
+              params.getSettings());
 
       var mainClass = dependenciesClassLoader.loadClass(params.getMainClassName());
       var constructor =

--- a/core/runner/src/test/java/me/seroperson/reload/live/runner/DevServerReloaderTest.java
+++ b/core/runner/src/test/java/me/seroperson/reload/live/runner/DevServerReloaderTest.java
@@ -1,0 +1,119 @@
+package me.seroperson.reload.live.runner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import me.seroperson.reload.live.ReloadGeneration;
+import me.seroperson.reload.live.runner.CompileResult.CompileSuccess;
+import me.seroperson.reload.live.settings.DevServerSettings;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class DevServerReloaderTest {
+
+  @TempDir File tempDir;
+
+  @Test
+  void reloadUsesPrefetchedCompileResult() throws Exception {
+    var compileDir = Files.createDirectory(tempDir.toPath().resolve("classes")).toFile();
+    var compileCount = new AtomicInteger();
+    var reloadRequested = new AtomicBoolean(true);
+    var settings =
+        new DevServerSettings(
+            List.of(),
+            List.of(
+                "-D" + DevServerSettings.LiveReloadCompileOnChange + "=true",
+                "-D" + DevServerSettings.LiveReloadCompileDebounceMs + "=50"),
+            Map.of());
+
+    try (var reloader =
+        new DevServerReloader(
+            ClassLoader.getSystemClassLoader(),
+            () -> {
+              compileCount.incrementAndGet();
+              return new CompileSuccess(List.of(compileDir));
+            },
+            () -> reloadRequested.getAndSet(false),
+            List.of(),
+            null,
+            settings)) {
+
+      reloader.scheduleBackgroundCompile();
+      Thread.sleep(200);
+
+      var first = reloader.reload();
+      assertInstanceOf(ReloadGeneration.class, first);
+      assertEquals(1, compileCount.get());
+
+      compileDir.setLastModified(System.currentTimeMillis() + 1000);
+      reloadRequested.set(true);
+      reloader.scheduleBackgroundCompile();
+      Thread.sleep(200);
+
+      var second = reloader.reload();
+      assertInstanceOf(ReloadGeneration.class, second);
+      assertEquals(2, compileCount.get());
+    }
+  }
+
+  @Test
+  void compileOnChangeDisabledAlwaysCompilesOnReload() throws Exception {
+    var compileDir = Files.createDirectory(tempDir.toPath().resolve("classes")).toFile();
+    var compileCount = new AtomicInteger();
+    var reloadRequested = new AtomicBoolean(true);
+    var settings =
+        new DevServerSettings(
+            List.of(),
+            List.of("-D" + DevServerSettings.LiveReloadCompileOnChange + "=false"),
+            Map.of());
+
+    try (var reloader =
+        new DevServerReloader(
+            ClassLoader.getSystemClassLoader(),
+            () -> {
+              compileCount.incrementAndGet();
+              return new CompileSuccess(List.of(compileDir));
+            },
+            () -> reloadRequested.getAndSet(false),
+            List.of(),
+            null,
+            settings)) {
+
+      var first = reloader.reload();
+      assertInstanceOf(ReloadGeneration.class, first);
+      assertEquals(1, compileCount.get());
+
+      compileDir.setLastModified(System.currentTimeMillis() + 1000);
+      reloadRequested.set(true);
+      var second = reloader.reload();
+      assertInstanceOf(ReloadGeneration.class, second);
+      assertEquals(2, compileCount.get());
+    }
+  }
+
+  @Test
+  void noReloadWhenClasspathUnchanged() throws Exception {
+    var compileDir = Files.createDirectory(tempDir.toPath().resolve("classes")).toFile();
+    var settings = new DevServerSettings(List.of(), List.of(), Map.of());
+
+    try (var reloader =
+        new DevServerReloader(
+            ClassLoader.getSystemClassLoader(),
+            () -> new CompileSuccess(List.of(compileDir)),
+            null,
+            List.of(),
+            null,
+            settings)) {
+
+      assertInstanceOf(ReloadGeneration.class, reloader.reload());
+      assertNull(reloader.reload());
+    }
+  }
+}

--- a/mill/src/DevSettingsKeys.scala
+++ b/mill/src/DevSettingsKeys.scala
@@ -20,5 +20,7 @@ object DevSettingsKeys {
   val LiveReloadGrpcProxyTlsKey: String = DevServerSettings.LiveReloadGrpcProxyTlsKey
   val LiveReloadIsDebug: String = DevServerSettings.LiveReloadIsDebug
   val LiveReloadThreadInterruptTimeout: String = DevServerSettings.LiveReloadThreadInterruptTimeout
+  val LiveReloadCompileOnChange: String = DevServerSettings.LiveReloadCompileOnChange
+  val LiveReloadCompileDebounceMs: String = DevServerSettings.LiveReloadCompileDebounceMs
   // format: on
 }

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
@@ -50,6 +50,8 @@ object LiveKeys {
     val LiveReloadGrpcProxyTlsKey: String = DevServerSettings.LiveReloadGrpcProxyTlsKey
     val LiveReloadIsDebug: String = DevServerSettings.LiveReloadIsDebug
     val LiveReloadThreadInterruptTimeout: String = DevServerSettings.LiveReloadThreadInterruptTimeout
+    val LiveReloadCompileOnChange: String = DevServerSettings.LiveReloadCompileOnChange
+    val LiveReloadCompileDebounceMs: String = DevServerSettings.LiveReloadCompileDebounceMs
     // format: on
   }
 


### PR DESCRIPTION
## Summary

Reload today compiles only when the next HTTP/gRPC request hits the proxy, so the first request after a save pays the full compile cost on top of app restart. This PR starts a **debounced background compile** when the file watcher detects changes (sbt/mill), and reuses that result on the next reload when it is ready.

Adds two settings (enabled by default):

- `live.reload.compile.on.change` / `LIVE_RELOAD_COMPILE_ON_CHANGE` (default `true`)
- `live.reload.compile.debounce.ms` / `LIVE_RELOAD_COMPILE_DEBOUNCE_MS` (default `300`)

App stop/start and health-check hooks are unchanged; only compile is moved earlier.

Fixes #50

## How was it tested?

- [x] New unit tests: `core/runner/src/test/java/me/seroperson/reload/live/runner/DevServerReloaderTest.java`
  - Prefetched compile is consumed on reload (compile supplier not called twice for one reload when prefetch is ready)
  - `live.reload.compile.on.change=false` restores synchronous compile-on-reload
  - No reload when classpath mtime is unchanged
- [ ] `./gradlew :core:runner:test :core:runner:spotlessJavaCheck`
- [ ] `just publish-local-sbt` then `just test-sbt` (after `core/` changes)
- [ ] `just code-format-check-all`

## Checklist

- [ ] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [ ] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support (n/a — no framework added)
- [x] No unrelated files were reformatted or refactored