### PR TITLE
Fix/grpc startup hook treat

### DIFF
--- a/core/build-link/build.gradle.kts
+++ b/core/build-link/build.gradle.kts
@@ -2,6 +2,19 @@ plugins {
     id("core-java-library")
 }
 
+dependencies {
+    implementation("io.grpc:grpc-netty-shaded:1.60.1")
+    implementation("io.grpc:grpc-stub:1.60.1")
+    implementation("io.grpc:grpc-services:1.60.1")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.12.2")
+    testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
 publishing {
     publications {
         named<MavenPublication>("mavenJava") {

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/GrpcHealthCheckHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/GrpcHealthCheckHook.java
@@ -1,34 +1,93 @@
 package me.seroperson.reload.live.hook;
 
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.TlsChannelCredentials;
+import io.grpc.health.v1.HealthCheckRequest;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.health.v1.HealthGrpc;
+import java.io.File;
 import java.io.IOException;
-import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+import me.seroperson.reload.live.UnrecoverableException;
 import me.seroperson.reload.live.build.BuildLogger;
+import me.seroperson.reload.live.settings.DevServerSettings;
 
 /**
- * Health check hook that uses GRPC health checking to determine server health.
+ * Health check hook that uses the GRPC health checking protocol to determine server health.
  *
- * <p>This hook performs health checks by connecting to the GRPC server and checking if it responds.
- * It uses a simple TCP connection check, as GRPC health checking protocol would require having the
- * GRPC dependencies which are not available in the build-link module.
+ * <p>Each probe issues a unary {@code grpc.health.v1.Health/Check} request and treats only
+ * {@code SERVING} as healthy. The configured service name is respected; an empty string checks the
+ * overall server status.
  */
 interface GrpcHealthCheckHook extends HealthCheckHook {
 
   @Override
   default int isHealthy(BuildLogger logger, String path, String host, int port) {
-    // For GRPC, we do a simple TCP connection check
-    // The 'path' parameter is ignored for GRPC - it's the service name for GRPC health check
-    try (Socket socket = new Socket(host, port)) {
-      socket.setSoTimeout(500);
-      // If we can connect, the server is at least accepting connections
-      // A more sophisticated check would use the GRPC health checking protocol,
-      // but that requires GRPC dependencies
-      return 1;
+    return isHealthy(
+        logger,
+        new DevServerSettings(
+            java.util.List.of(),
+            java.util.List.of(),
+            java.util.Map.of(
+                DevServerSettings.LiveReloadGrpcHost,
+                host,
+                DevServerSettings.LiveReloadGrpcPort,
+                String.valueOf(port),
+                DevServerSettings.LiveReloadGrpcHealthService,
+                path == null ? "" : path)));
+  }
+
+  default int isHealthy(BuildLogger logger, DevServerSettings settings) {
+    var host = settings.getGrpcHost();
+    var port = settings.getGrpcPort();
+    var service = settings.getGrpcHealthService();
+    ChannelCredentials credentials =
+        settings.isGrpcTargetTls()
+            ? buildTlsCredentials(settings.getGrpcTargetTlsTrust())
+            : InsecureChannelCredentials.create();
+    ManagedChannel channel = Grpc.newChannelBuilderForAddress(host, port, credentials).build();
+    try {
+      var stub = HealthGrpc.newBlockingStub(channel).withDeadlineAfter(1, TimeUnit.SECONDS);
+      var request =
+          HealthCheckRequest.newBuilder().setService(service == null ? "" : service).build();
+      var response = stub.check(request);
+      return response.getStatus() == HealthCheckResponse.ServingStatus.SERVING ? 1 : 0;
+    } catch (StatusRuntimeException ex) {
+      var code = ex.getStatus().getCode();
+      if (code == Status.Code.UNIMPLEMENTED) {
+        return 404;
+      }
+      return -1;
+    } catch (Exception ex) {
+      logger.error("Error during GRPC health check", ex);
+      return -1;
+    } finally {
+      channel.shutdownNow();
+      try {
+        channel.awaitTermination(1, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    }
+  }
+
+  private static ChannelCredentials buildTlsCredentials(String trustPath) {
+    if (trustPath == null || trustPath.isEmpty()) {
+      return TlsChannelCredentials.create();
+    }
+    try {
+      return TlsChannelCredentials.newBuilder().trustManager(new File(trustPath)).build();
     } catch (IOException e) {
-      // Connection failed - server is not ready
-      return -1;
-    } catch (Exception e) {
-      logger.error("Error during GRPC health check", e);
-      return -1;
+      throw new UnrecoverableException(
+          "Failed to read GRPC target TLS trust material from "
+              + trustPath
+              + ": "
+              + e.getMessage());
     }
   }
 }

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/GrpcHealthCheckHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/GrpcHealthCheckHook.java
@@ -20,9 +20,9 @@ import me.seroperson.reload.live.settings.DevServerSettings;
 /**
  * Health check hook that uses the GRPC health checking protocol to determine server health.
  *
- * <p>Each probe issues a unary {@code grpc.health.v1.Health/Check} request and treats only
- * {@code SERVING} as healthy. The configured service name is respected; an empty string checks the
- * overall server status.
+ * <p>Each probe issues a unary {@code grpc.health.v1.Health/Check} request and treats only {@code
+ * SERVING} as healthy. The configured service name is respected; an empty string checks the overall
+ * server status.
  */
 interface GrpcHealthCheckHook extends HealthCheckHook {
 

--- a/core/build-link/src/test/java/me/seroperson/reload/live/hook/GrpcHealthCheckStartupHookTest.java
+++ b/core/build-link/src/test/java/me/seroperson/reload/live/hook/GrpcHealthCheckStartupHookTest.java
@@ -72,7 +72,9 @@ class GrpcHealthCheckStartupHookTest {
 
       assertTrue(
           elapsedMs >= 900L,
-          "startup hook returned too early after only " + elapsedMs + "ms while health was NOT_SERVING");
+          "startup hook returned too early after only "
+              + elapsedMs
+              + "ms while health was NOT_SERVING");
       assertTrue(ready.get(), "server should be marked ready before startup hook returns");
     } finally {
       server.shutdownNow();
@@ -121,8 +123,7 @@ class GrpcHealthCheckStartupHookTest {
     }
   }
 
-  private static final class ByteArrayMarshaller
-      implements MethodDescriptor.Marshaller<byte[]> {
+  private static final class ByteArrayMarshaller implements MethodDescriptor.Marshaller<byte[]> {
     @Override
     public InputStream stream(byte[] value) {
       return new ByteArrayInputStream(value);

--- a/core/build-link/src/test/java/me/seroperson/reload/live/hook/GrpcHealthCheckStartupHookTest.java
+++ b/core/build-link/src/test/java/me/seroperson/reload/live/hook/GrpcHealthCheckStartupHookTest.java
@@ -1,0 +1,160 @@
+package me.seroperson.reload.live.hook;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import io.grpc.BindableService;
+import io.grpc.MethodDescriptor;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerServiceDefinition;
+import io.grpc.Status;
+import io.grpc.health.v1.HealthCheckResponse;
+import io.grpc.protobuf.services.HealthStatusManager;
+import io.grpc.stub.ServerCalls;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import me.seroperson.reload.live.build.BuildLogger;
+import me.seroperson.reload.live.settings.DevServerSettings;
+import org.junit.jupiter.api.Test;
+
+class GrpcHealthCheckStartupHookTest {
+
+  @Test
+  void waitsUntilServingInsteadOfReturningOnPortBind() throws Exception {
+    int port = freePort();
+    AtomicBoolean ready = new AtomicBoolean(false);
+    HealthStatusManager health = new HealthStatusManager();
+    health.setStatus("", HealthCheckResponse.ServingStatus.NOT_SERVING);
+
+    Server server =
+        ServerBuilder.forPort(port)
+            .addService(new GreeterService(ready))
+            .addService(health.getHealthService())
+            .build()
+            .start();
+
+    Thread promoter =
+        new Thread(
+            () -> {
+              try {
+                Thread.sleep(1000L);
+                ready.set(true);
+                health.setStatus("", HealthCheckResponse.ServingStatus.SERVING);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    promoter.start();
+
+    DevServerSettings settings =
+        new DevServerSettings(
+            List.of(),
+            List.of(),
+            Map.of(
+                DevServerSettings.LiveReloadGrpcHost,
+                "localhost",
+                DevServerSettings.LiveReloadGrpcPort,
+                String.valueOf(port),
+                DevServerSettings.LiveReloadGrpcHealthService,
+                ""));
+
+    try {
+      long start = System.nanoTime();
+      new GrpcHealthCheckStartupHook()
+          .hook(new Thread(), ClassLoader.getSystemClassLoader(), settings, new NoopLogger());
+      long elapsedMs = (System.nanoTime() - start) / 1_000_000L;
+
+      assertTrue(
+          elapsedMs >= 900L,
+          "startup hook returned too early after only " + elapsedMs + "ms while health was NOT_SERVING");
+      assertTrue(ready.get(), "server should be marked ready before startup hook returns");
+    } finally {
+      server.shutdownNow();
+      server.awaitTermination();
+    }
+  }
+
+  private static int freePort() throws IOException {
+    try (ServerSocket socket = new ServerSocket(0)) {
+      return socket.getLocalPort();
+    }
+  }
+
+  private static final class GreeterService implements BindableService {
+    private final AtomicBoolean ready;
+
+    private GreeterService(AtomicBoolean ready) {
+      this.ready = ready;
+    }
+
+    @Override
+    public ServerServiceDefinition bindService() {
+      MethodDescriptor<byte[], byte[]> methodDescriptor =
+          MethodDescriptor.<byte[], byte[]>newBuilder()
+              .setType(MethodDescriptor.MethodType.UNARY)
+              .setFullMethodName("greeter.Greeter/Greet")
+              .setRequestMarshaller(new ByteArrayMarshaller())
+              .setResponseMarshaller(new ByteArrayMarshaller())
+              .build();
+
+      ServerCallHandler<byte[], byte[]> handler =
+          ServerCalls.asyncUnaryCall(
+              (request, responseObserver) -> {
+                if (!ready.get()) {
+                  responseObserver.onError(
+                      Status.UNAVAILABLE.withDescription("warming up").asRuntimeException());
+                } else {
+                  responseObserver.onNext("READY".getBytes());
+                  responseObserver.onCompleted();
+                }
+              });
+
+      return ServerServiceDefinition.builder("greeter.Greeter")
+          .addMethod(methodDescriptor, handler)
+          .build();
+    }
+  }
+
+  private static final class ByteArrayMarshaller
+      implements MethodDescriptor.Marshaller<byte[]> {
+    @Override
+    public InputStream stream(byte[] value) {
+      return new ByteArrayInputStream(value);
+    }
+
+    @Override
+    public byte[] parse(InputStream stream) {
+      try {
+        return stream.readAllBytes();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  private static final class NoopLogger implements BuildLogger {
+    @Override
+    public void debug(String message) {}
+
+    @Override
+    public void info(String message) {}
+
+    @Override
+    public void warn(String message) {}
+
+    @Override
+    public void error(Throwable t) {}
+
+    @Override
+    public void error(String message, Throwable t) {}
+
+    @Override
+    public void error(String message) {}
+  }
+}


### PR DESCRIPTION
## Summary
Fixes #54: the legacy `build-link` gRPC startup hook no longer treats any open TCP port as a healthy server.

Before this change, `me.seroperson.reload.live.hook.GrpcHealthCheckStartupHook` returned success as soon as it could connect to the target port. That allowed the proxy to route requests while the target gRPC application was still reporting `NOT_SERVING` and still rejecting real RPCs.

This change replaces the TCP-only readiness check with a real `grpc.health.v1.Health/Check` probe. The hook now waits for `SERVING`, respects `live.reload.grpc.health.service`, and supports TLS target probing.
## Related Issue
Closes #54
## Change Type
- [x] Bug fix
- [x] Regression test
- [x] Build/test configuration update
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement

## Real Behavior Proof
The original bug was reproduced with the real built hook and a live gRPC server that bound early but stayed unhealthy:
```text
SERVER_BOUND port=58081 health=NOT_SERVING
DEBUG Waiting for the GRPC health-check to return success ...
HOOK_RETURNED_AFTER_MS=108
HEALTH_IMMEDIATE=NOT_SERVING
GREETER_IMMEDIATE_ERROR=Status{code=UNAVAILABLE, description=warming up, cause=null}
SERVER_READY_AFTER_MS=5000
HEALTH_LATER=SERVING
GREETER_LATER=READY
```

That showed the old hook returning in about `108ms` even though:

- gRPC health was still `NOT_SERVING`
- real application RPCs still failed with `UNAVAILABLE`

After the fix, the regression test enforces that the hook waits until the server transitions to `SERVING`.
## Validation

Commands run successfully:
```sh
./gradlew --no-configuration-cache :core:build-link:test --tests 'me.seroperson.reload.live.hook.GrpcHealthCheckStartupHookTest'
```

```sh
./gradlew --no-configuration-cache :core:webserver-grpc:jar :core:build-link:test --tests 'me.seroperson.reload.live.hook.GrpcHealthCheckStartupHookTest'
```

```sh
just code-format-check-gradle
```

Observed result:

```text
BUILD SUCCESSFUL
```

## Checklist
- [x] Analyzed the legacy gRPC startup hook implementation
- [x] Confirmed it used raw TCP connect instead of gRPC health protocol
- [x] Replaced readiness probing with real `grpc.health.v1.Health/Check`
- [x] Preserved service-name and TLS-aware behavior
- [x] Added a regression test for delayed `NOT_SERVING -> SERVING`
- [x] Verified the new regression test passes
- [x] Verified `core:webserver-grpc` still builds against the updated hook implementation
- [x] Applied Java formatting fixes required by Spotless
- [x] Re-ran Gradle formatting checks successfully