### PR TITLE
fix: gradle plugin leaks live-reload dependencies

### DIFF
--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadDependencyLeakTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadDependencyLeakTest.kt
@@ -1,0 +1,101 @@
+package me.seroperson.reload.live.gradle
+
+import org.gradle.testkit.runner.TaskOutcome
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class LiveReloadDependencyLeakTest : LiveReloadTestBase() {
+    @field:TempDir lateinit var projectDir: File
+
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+    private val appCode by lazy {
+        val javaSources = projectDir.resolve("src/main/java/example")
+        javaSources.mkdirs()
+        javaSources.resolve("App.java")
+    }
+
+    @Test
+    fun `plugin does not leak live reload runtime into app runtime classpath or pom`() {
+        settingsFile.writeText("rootProject.name = \"dependency-leak-test\"")
+        buildFile.writeText(BUILD_CONTENT)
+        appCode.writeText(APP_CODE)
+
+        val dependenciesResult =
+            initGradleRunner("dependencies", projectDir)
+                .withArguments("dependencies", "--configuration", "runtimeClasspath")
+                .build()
+        val runtimeOutput = dependenciesResult.output
+
+        assertFalse(
+            runtimeOutput.contains("me.seroperson:jvm-live-reload-webserver"),
+            "runtimeClasspath should not contain the HTTP live-reload proxy",
+        )
+        assertFalse(
+            runtimeOutput.contains("me.seroperson:jvm-live-reload-webserver-grpc"),
+            "runtimeClasspath should not contain the gRPC live-reload proxy",
+        )
+
+        val pomResult =
+            initGradleRunner("generatePomFileForMavenJavaPublication", projectDir)
+                .withArguments("generatePomFileForMavenJavaPublication")
+                .build()
+        val pomFile = projectDir.resolve("build/publications/mavenJava/pom-default.xml")
+        val pom = pomFile.readText()
+
+        assertFalse(
+            pom.contains("jvm-live-reload-webserver"),
+            "published POM should not contain the HTTP live-reload proxy",
+        )
+        assertFalse(
+            pom.contains("jvm-live-reload-webserver-grpc"),
+            "published POM should not contain the gRPC live-reload proxy",
+        )
+        kotlin.test.assertEquals(
+            TaskOutcome.SUCCESS,
+            pomResult.task(":generatePomFileForMavenJavaPublication")?.outcome,
+        )
+    }
+
+    companion object {
+        const val BUILD_CONTENT =
+            """
+plugins {
+    java
+    application
+    `maven-publish`
+    id("me.seroperson.reload.live.gradle")
+}
+
+group = "example"
+version = "1.0.0"
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("mavenJava") {
+            from(components["java"])
+        }
+    }
+}
+
+application { mainClass = "example.App" }
+"""
+
+        const val APP_CODE =
+            """
+package example;
+
+public class App {}
+"""
+    }
+}

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadPlugin.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadPlugin.kt
@@ -4,6 +4,7 @@ import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.SourceDirectorySet
@@ -26,6 +27,7 @@ import org.slf4j.LoggerFactory
 class LiveReloadPlugin : Plugin<Project> {
     override fun apply(project: Project) {
         val extension = createExtension(project)
+        val liveReloadRuntime = createLiveReloadRuntimeConfiguration(project)
         createRunTask(project, extension)
 
         project.afterEvaluate {
@@ -34,7 +36,9 @@ class LiveReloadPlugin : Plugin<Project> {
                     ServerType.HTTP -> "me.seroperson:jvm-live-reload-webserver:${BuildConfig.VERSION}"
                     ServerType.GRPC -> "me.seroperson:jvm-live-reload-webserver-grpc:${BuildConfig.VERSION}"
                 }
-            project.dependencies.add("implementation", dependency)
+            project.dependencies.add(liveReloadRuntime.name, dependency)
+            val liveReloadRun = project.tasks.getByName("liveReloadRun") as LiveReloadRun
+            liveReloadRun.runtimeClasspath.from(liveReloadRuntime)
         }
     }
 
@@ -56,6 +60,14 @@ class LiveReloadPlugin : Plugin<Project> {
 
     private fun createExtension(project: Project): LiveReloadExtension =
         project.extensions.create("liveReload", LiveReloadExtension::class.java)
+
+    private fun createLiveReloadRuntimeConfiguration(project: Project): Configuration =
+        project.configurations.create("liveReloadRuntime").apply {
+            isCanBeConsumed = false
+            isCanBeResolved = true
+            isVisible = false
+            description = "Task-local runtime for the live-reload proxy implementation."
+        }
 
     private fun createRunTask(
         project: Project,


### PR DESCRIPTION
## Summary
Fixes #56: applying the Gradle live-reload plugin no longer leaks dev-only live-reload server artifacts into the application's normal runtime classpath or published POM.
Before this change, the plugin added `jvm-live-reload-webserver` or `jvm-live-reload-webserver-grpc` to the project's `implementation` configuration. That meant a development-only proxy dependency appeared in:

- the app's regular `runtimeClasspath`
- generated Maven publication metadata
- downstream consumers of published artifacts

This change isolates the proxy dependency to the `liveReloadRun` task by moving it to an internal task-local runtime configuration.
## Related Issue
Closes #56
## Change Type
- [x] Bug fix
- [x] Regression test
- [x] Build/plugin wiring update
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactor
- [ ] Performance improvement
## Real Behavior Proof
Verified in a fresh external Gradle consumer using the locally published plugin.
Runtime classpath after the fix:
```text
runtimeClasspath - Runtime classpath of source set 'main'.
No dependencies
```
Published POM after the fix:

```xml
<project ...>
  <modelVersion>4.0.0</modelVersion>
  <groupId>example</groupId>
  <artifactId>jlr-gradle-fixed</artifactId>
  <version>1.0.0</version>
</project>
```

That POM contains no `jvm-live-reload-webserver` or `jvm-live-reload-webserver-grpc` dependency entries.

The focused Gradle functional test also passed and printed:
```text
runtimeClasspath - Runtime classpath of source set 'main'.
No dependencies
BUILD SUCCESSFUL
```
## Checklist

- [x] Analyzed the Gradle plugin dependency wiring
- [x] Confirmed the plugin was leaking proxy artifacts through `implementation`
- [x] Moved the proxy dependency into an internal task-local runtime configuration
- [x] Kept `liveReloadRun` working with its own dedicated runtime classpath
- [x] Added a functional regression test for runtime classpath and published POM leakage
- [x] Verified the new Gradle functional test passes
- [x] Verified a fresh external consumer no longer sees leaked runtime dependencies
- [x] Verified the generated published POM no longer contains live-reload artifacts
- [x] Ran Gradle formatting checks successfully