### PR TITLE
fix(health): normalize REST health check path with leading slash

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/RestApiHealthCheckHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/RestApiHealthCheckHook.java
@@ -13,9 +13,20 @@ import me.seroperson.reload.live.build.BuildLogger;
  */
 interface RestApiHealthCheckHook extends HealthCheckHook {
 
+  /**
+   * Ensures REST health probes use a path segment (e.g. {@code /health}), not {@code health}.
+   */
+  default String normalizeHealthCheckPath(String path) {
+    if (path == null || path.isEmpty()) {
+      return path;
+    }
+    return path.startsWith("/") ? path : "/" + path;
+  }
+
   default int isHealthy(BuildLogger logger, String path, String host, int port) {
     try {
-      var url = new URI("http://" + host + ":" + port + path).toURL();
+      var normalizedPath = normalizeHealthCheckPath(path);
+      var url = new URI("http://" + host + ":" + port + normalizedPath).toURL();
       HttpURLConnection connection = (HttpURLConnection) url.openConnection();
       connection.setRequestProperty("Connection", "close");
       connection.setReadTimeout(500);


### PR DESCRIPTION
## Summary

Normalize REST health check paths to include a leading slash so probe URLs are built correctly when the configured path omits it.

## Related Issues

Closes #58

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other (describe below)

## Testing

- [ ] Tests added/updated
- [x] Manually tested

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Changes are documented (if applicable)
