### PR TITLE
fix: publishLocal for mill plugin now includes transitive internal deps

### DIFF
--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ test-mill: publish-local-mill
   {{ mill }} mill-live-reload.integration.testLocal
 
 publish-local-mill: calculate-version
-  {{ mill }} mill-live-reload.publishLocal
+  {{ mill }} mill-live-reload.publishLocal --transitive true
 
 publish-mill: calculate-version
   {{ mill }} mill-live-reload.publishSonatypeCentral

--- a/mill/integration/src/IntegrationTests.scala
+++ b/mill/integration/src/IntegrationTests.scala
@@ -456,4 +456,28 @@ class IntegrationTests extends AnyFunSuite with RequestMaker {
     assert(initial && reloaded)
   }
 
+  // Regression for: publishLocal only published mill-live-reload itself, omitting
+  // transitive internal modules (runner, webserver, build-link). An external project
+  // using a snapshot version would fail to resolve those deps at meta-build time.
+  test("publishLocal-transitive-resolution") {
+    val resourceDir = os.Path(BuildInfo.resourceDir) / "http4s-with-resources"
+
+    val tester = new IntegrationTester(
+      daemonMode = false,
+      workspaceSourcePath = resourceDir,
+      millExecutable = os.Path(BuildInfo.exePath)
+    )
+
+    val result = tester.eval(
+      "app.compile",
+      env = Map("PLUGIN_VERSION" -> BuildInfo.version),
+      stdout = ProcessOutput.Readlines(v => println(v)),
+      mergeErrIntoOut = true
+    )
+
+    tester.close()
+
+    assert(result.isSuccess)
+  }
+
 }


### PR DESCRIPTION
## Summary

Fixes #52

`just publish-local-mill` called `mill mill-live-reload.publishLocal` without
`--transitive true`, so only the plugin artifact itself was published to the
local Ivy cache. Transitive internal modules (`jvm-live-reload-runner`,
`jvm-live-reload-webserver`, `jvm-live-reload-build-link`) were omitted,
causing any external mill project that depends on a snapshot version to fail
at meta-build dependency resolution before it could even compile.

## How was it tested?

- New test — `mill/integration/src/IntegrationTests.scala` `"publishLocal-transitive-resolution"`:
  uses the existing `http4s-with-resources` fixture, runs `app.compile` with
  `PLUGIN_VERSION` set to the locally published snapshot, and asserts the result
  succeeds. Without the `--transitive true` flag, the mill meta-build fails to
  resolve the plugin's internal deps and this test fails.

## Checklist

- [ ] I ran the relevant test recipe locally (`just test-mill`)
- [ ] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [ ] No unrelated files were reformatted or refactored
