### PR TITLE
fix: bound cats-effect shutdown hook join with timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ First, let's check the list of available options:
 | `live.reload.grpc.proxy.tls.cert`   | `LIVE_RELOAD_GRPC_PROXY_TLS_CERT`   | `""`        | Path to a PEM-encoded certificate chain used by the proxy listener (paired with the key below)                                                      |
 | `live.reload.grpc.proxy.tls.key`    | `LIVE_RELOAD_GRPC_PROXY_TLS_KEY`    | `""`        | Path to a PEM-encoded private key used by the proxy listener (when both this and the cert are set, the proxy listens with TLS instead of plaintext) |
 | `live.reload.debug`                 | `LIVE_RELOAD_DEBUG`                 | `false`     | Whether to enable/disable debug output                                                                                                              |
-| `live.reload.thread.interrupt.timeout` | `LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT` | `15000`  | How long (ms) the interrupt-based shutdown hooks (`ThreadInterruptShutdownHook` and the cats-effect `IoAppEffectShutdownHook`) wait for the application's main thread to exit after `Thread.interrupt()`. If it doesn't, the reload aborts with an unrecoverable error rather than continuing with a stale thread. |
+| `live.reload.thread.interrupt.timeout` | `LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT` | `15000`  | How long (ms) the interrupt-based shutdown hooks wait for the application's main thread to exit after `Thread.interrupt()`. If it doesn't, the reload aborts with an unrecoverable error rather than continuing with a stale thread. |
 
 To change variables using build configuration, use the following key for `sbt`:
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ First, let's check the list of available options:
 | `live.reload.grpc.proxy.tls.cert`   | `LIVE_RELOAD_GRPC_PROXY_TLS_CERT`   | `""`        | Path to a PEM-encoded certificate chain used by the proxy listener (paired with the key below)                                                      |
 | `live.reload.grpc.proxy.tls.key`    | `LIVE_RELOAD_GRPC_PROXY_TLS_KEY`    | `""`        | Path to a PEM-encoded private key used by the proxy listener (when both this and the cert are set, the proxy listens with TLS instead of plaintext) |
 | `live.reload.debug`                 | `LIVE_RELOAD_DEBUG`                 | `false`     | Whether to enable/disable debug output                                                                                                              |
-| `live.reload.thread.interrupt.timeout` | `LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT` | `15000`  | How long (ms) `ThreadInterruptShutdownHook` waits for the application's main thread to exit after `Thread.interrupt()`. If it doesn't, the reload aborts with an unrecoverable error rather than continuing with a stale thread. |
+| `live.reload.thread.interrupt.timeout` | `LIVE_RELOAD_THREAD_INTERRUPT_TIMEOUT` | `15000`  | How long (ms) the interrupt-based shutdown hooks (`ThreadInterruptShutdownHook` and the cats-effect `IoAppEffectShutdownHook`) wait for the application's main thread to exit after `Thread.interrupt()`. If it doesn't, the reload aborts with an unrecoverable error rather than continuing with a stale thread. |
 
 To change variables using build configuration, use the following key for `sbt`:
 

--- a/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
+++ b/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
@@ -38,7 +38,7 @@ class IoAppEffectShutdownHook extends Hook {
     val appThreadGroup = th.getThreadGroup
     th.interrupt()
     logger.debug(
-     s"Waiting up to ${timeoutMs}ms for cats-effect thread to finish"
+      s"Waiting up to ${timeoutMs}ms for cats-effect thread to finish"
     )
     th.join(timeoutMs)
     if (th.isAlive) {

--- a/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
+++ b/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
@@ -40,9 +40,6 @@ class IoAppEffectShutdownHook extends Hook {
     logger.debug(s"Waiting up to ${timeoutMs}ms for cats-effect thread to finish")
     th.join(timeoutMs)
     if (th.isAlive) {
-      // main() ignored the interrupt (e.g. an uncancelable region or a
-      // non-interruptible IO.blocking call). Abort the reload instead of
-      // joining forever and wedging the dev server.
       throw new UnrecoverableException(
         s"Cats Effect application thread '${th.getName}' did not exit within " +
           s"${timeoutMs}ms after interrupt. Configure " +

--- a/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
+++ b/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
@@ -37,7 +37,9 @@ class IoAppEffectShutdownHook extends Hook {
 
     val appThreadGroup = th.getThreadGroup
     th.interrupt()
-    logger.debug(s"Waiting up to ${timeoutMs}ms for cats-effect thread to finish")
+    logger.debug(
+     s"Waiting up to ${timeoutMs}ms for cats-effect thread to finish"
+    )
     th.join(timeoutMs)
     if (th.isAlive) {
       throw new UnrecoverableException(

--- a/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
+++ b/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppEffectShutdownHook.scala
@@ -3,6 +3,7 @@ package cats.effect
 import cats.effect.unsafe.IORuntime
 import java.lang.management.ManagementFactory
 import javax.management.ObjectName
+import me.seroperson.reload.live.UnrecoverableException
 import me.seroperson.reload.live.build.BuildLogger
 import me.seroperson.reload.live.hook.Hook
 import me.seroperson.reload.live.reflect.MiscUtils
@@ -32,9 +33,22 @@ class IoAppEffectShutdownHook extends Hook {
       settings: DevServerSettings,
       logger: BuildLogger
   ): Unit = {
+    val timeoutMs: Long = settings.getThreadInterruptTimeoutMs()
+
     val appThreadGroup = th.getThreadGroup
     th.interrupt()
-    th.join()
+    logger.debug(s"Waiting up to ${timeoutMs}ms for cats-effect thread to finish")
+    th.join(timeoutMs)
+    if (th.isAlive) {
+      // main() ignored the interrupt (e.g. an uncancelable region or a
+      // non-interruptible IO.blocking call). Abort the reload instead of
+      // joining forever and wedging the dev server.
+      throw new UnrecoverableException(
+        s"Cats Effect application thread '${th.getName}' did not exit within " +
+          s"${timeoutMs}ms after interrupt. Configure " +
+          s"'${DevServerSettings.LiveReloadThreadInterruptTimeout}' to adjust the timeout."
+      )
+    }
 
     if (appThreadGroup != null) {
       val threads = new Array[Thread](appThreadGroup.activeCount())
@@ -43,7 +57,14 @@ class IoAppEffectShutdownHook extends Hook {
       cancelHook match {
         case Some(hook) =>
           logger.debug(s"Found cats-effect cancel hook")
-          hook.join()
+          hook.join(timeoutMs)
+          if (hook.isAlive) {
+            throw new UnrecoverableException(
+              s"Cats Effect cancel hook '${hook.getName}' did not finish within " +
+                s"${timeoutMs}ms. Configure " +
+                s"'${DevServerSettings.LiveReloadThreadInterruptTimeout}' to adjust the timeout."
+            )
+          }
         case None =>
           logger.debug(s"cats-effect wasn't found")
       }


### PR DESCRIPTION
## What

The cats-effect `IoAppEffectShutdownHook` interrupted the application thread and then called `th.join()` (and `hook.join()` for the `io-cancel` thread) with **no timeout**. If a Cats Effect app does not terminate promptly after the interrupt (uncancelable region, non-interruptible `IO.blocking`, or a swallowed `InterruptedException`), the join never returns and the whole reload/teardown path wedges forever - `kill -9` only.

This is the same failure mode already fixed for the generic `ThreadInterruptShutdownHook` in #16 / #20; that hook was bounded, but the cats-effect-specific shutdown hook was overlooked.

## Change

- Bound both joins in `IoAppEffectShutdownHook` using the existing `live.reload.thread.interrupt.timeout` setting (`settings.getThreadInterruptTimeoutMs()`, default 15000ms).
- If the application thread (or the `io-cancel` hook thread) is still alive after the timeout, throw `UnrecoverableException` so the proxy aborts the reload with a clear message instead of hanging - consistent with `ThreadInterruptShutdownHook`.
- Updated the README config table to note the setting now also governs the cats-effect shutdown hook.

## Notes

The interrupt-timeout behaviour now matches between `ThreadInterruptShutdownHook` and `IoAppEffectShutdownHook`. The sbt scripted cats-effect fixtures should exercise this on CI.

Fixes #61