### PR TITLE
fix: tolerate transient 404 from health-check during app warmup

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckShutdownHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckShutdownHook.java
@@ -13,6 +13,14 @@ import me.seroperson.reload.live.settings.DevServerSettings;
  */
 public abstract class HealthCheckShutdownHook implements HealthCheckHook {
 
+  /**
+   * During teardown the application may answer {@code 404} (routes already deregistered) while its
+   * listen socket is still open. Such a {@code 404} is transient and must not abort the reload;
+   * only a {@code 404} that persists beyond this grace window means the health route was never
+   * implemented.
+   */
+  private static final long NOT_IMPLEMENTED_GRACE_MS = 5000L;
+
   @Override
   public String description() {
     return "Waits for health-check to return false";
@@ -26,24 +34,38 @@ public abstract class HealthCheckShutdownHook implements HealthCheckHook {
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
     try {
+      // Deadline after which a still-ongoing 404 is treated as "not implemented".
+      // -1 means no 404 has been observed yet (or the streak was broken).
+      long notImplementedDeadline = -1L;
       while (true) {
         logger.debug("Waiting for the health-check to return failure ...");
         var path = settings.getHealthCheckPath();
         var healthResponse =
             isHealthy(logger, path, settings.getHttpHost(), settings.getHttpPort());
-        if (healthResponse == 1) {
-          // success
-          Thread.sleep(50L);
-        } else if (healthResponse == 0) {
-          // non-success response, but not an exception
-          Thread.sleep(50L);
-        } else if (healthResponse == -1) {
+        if (healthResponse == -1) {
           // connection exception, that's what we're looking for
           return;
         } else if (healthResponse == 404) {
-          // if health check isn't implemented, don't poll it
-          throw new UnrecoverableException(
-              "Health-check route " + path + " responded with 404. Is it implemented?");
+          // The old generation is still serving on its socket but may have deregistered routes
+          // mid-teardown. Keep polling until the connection is actually refused; only give up if
+          // 404 persists past the grace window (health route genuinely not implemented).
+          long now = System.currentTimeMillis();
+          if (notImplementedDeadline < 0L) {
+            notImplementedDeadline = now + NOT_IMPLEMENTED_GRACE_MS;
+          } else if (now >= notImplementedDeadline) {
+            throw new UnrecoverableException(
+                "Health-check route "
+                    + path
+                    + " kept responding with 404 for over "
+                    + NOT_IMPLEMENTED_GRACE_MS
+                    + "ms. Is it implemented?");
+          }
+          Thread.sleep(50L);
+        } else {
+          // healthResponse == 1 (still healthy) or 0 (reachable, non-success): the old generation
+          // is still up. Reset the 404 grace window and keep polling.
+          notImplementedDeadline = -1L;
+          Thread.sleep(50L);
         }
       }
     } catch (InterruptedException e) {

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckStartupHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckStartupHook.java
@@ -13,6 +13,14 @@ import me.seroperson.reload.live.settings.DevServerSettings;
  */
 public abstract class HealthCheckStartupHook implements HealthCheckHook {
 
+  /**
+   * A {@code 404} during application warmup is expected: most JVM web frameworks bind the listen
+   * socket before registering their routes, so the configured health route transiently returns
+   * {@code 404} until startup completes. Only a {@code 404} that persists beyond this grace window
+   * is treated as a genuinely missing/misconfigured health route.
+   */
+  private static final long NOT_IMPLEMENTED_GRACE_MS = 5000L;
+
   @Override
   public String description() {
     return "Waits for health-check to return true";
@@ -26,6 +34,9 @@ public abstract class HealthCheckStartupHook implements HealthCheckHook {
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
     try {
+      // Deadline after which a still-ongoing 404 is treated as "not implemented".
+      // -1 means no 404 has been observed yet (or the streak was broken).
+      long notImplementedDeadline = -1L;
       while (true) {
         AppFailureRegistry.throwIfFailed(th);
         logger.debug("Waiting for the health-check to return success ...");
@@ -35,16 +46,26 @@ public abstract class HealthCheckStartupHook implements HealthCheckHook {
         if (healthResponse == 1) {
           // success
           return;
-        } else if (healthResponse == 0) {
-          // non-success response, but not an exception
-          Thread.sleep(50L);
-        } else if (healthResponse == -1) {
-          // connection exception
-          Thread.sleep(50L);
         } else if (healthResponse == 404) {
-          // health-check isn't implemented?
-          throw new UnrecoverableException(
-              "Health-check route " + path + " responded with 404. Is it implemented?");
+          // The server is reachable but the health route may not be registered yet during
+          // warmup. Keep polling, and only give up once 404 persists past the grace window.
+          long now = System.currentTimeMillis();
+          if (notImplementedDeadline < 0L) {
+            notImplementedDeadline = now + NOT_IMPLEMENTED_GRACE_MS;
+          } else if (now >= notImplementedDeadline) {
+            throw new UnrecoverableException(
+                "Health-check route "
+                    + path
+                    + " kept responding with 404 for over "
+                    + NOT_IMPLEMENTED_GRACE_MS
+                    + "ms. Is it implemented?");
+          }
+          Thread.sleep(50L);
+        } else {
+          // healthResponse == 0 (non-success response) or -1 (connection exception): the app is
+          // still coming up. Reset the 404 grace window and keep polling.
+          notImplementedDeadline = -1L;
+          Thread.sleep(50L);
         }
       }
     } catch (InterruptedException e) {


### PR DESCRIPTION
## Describe the bug

The HTTP health-check hooks treat **any** `404` from the health endpoint as a fatal, unrecoverable "route not implemented" error and throw `UnrecoverableException`, killing the reload/dev-server. But a `404` is a normal, *transient* response during application **warmup**: most JVM web frameworks (Spring Boot, Play, http4s, Pekko/Akka HTTP, Vert.x, …) bind and start accepting connections on the listen socket **before** registering their routes. In that window the server is already up and answers HTTP, but returns `404` for every path — including `/health` — until route registration completes.

The startup hook's whole job is to *poll and wait* for readiness, yet a single transient `404` was immediately fatal: unlike `0` (non-2xx) and `-1` (connection refused/timeout), which both sleep and retry, `404` was the only non-success code that broke the loop by throwing. Because the startup hook runs after **every** reload, this could fire mid-session right after editing code. The shutdown hook had the symmetric teardown problem (routes deregistered before the socket closes).

This is distinct from the existing "polls forever / no timeout" issues (the opposite failure mode) and from the missing-leading-slash issue (here the path is correct and the route exists).

## Fix

Treat a `404` as a *not-ready-yet* signal and keep polling, escalating to `UnrecoverableException` only when the `404` **persists past a grace window** (`NOT_IMPLEMENTED_GRACE_MS`, 5s) — so a correctly configured app is never killed by a transient warmup/teardown `404`, while a genuinely missing health route is still reported. Any non-404 response resets the grace window. Applied symmetrically to `HealthCheckStartupHook` and `HealthCheckShutdownHook`.

## How was it tested?

Manual review of the polling state machine for both hooks; the `int` return contract of `isHealthy` is unchanged.