### PR TITLE
fix: mill live reload watch inputs

### DIFF
--- a/mill/integration/src/IntegrationTests.scala
+++ b/mill/integration/src/IntegrationTests.scala
@@ -145,12 +145,14 @@ class IntegrationTests extends AnyFunSuite with RequestMaker {
 
     val greet = runUntil("http://localhost:9000/greet", 200, "Hello World 1")
     tester.modifyFile(
-      tester.workspacePath / "app" / "src" / "App.scala",
-      _ => os.read(resourceDir / "changes" / "App.scala.1")
-    )
-    tester.modifyFile(
       tester.workspacePath / "app" / "resources" / "application.conf",
       _ => os.read(resourceDir / "changes" / "application.conf.1")
+    )
+    val greetResourceReloaded =
+      runUntil("http://localhost:9000/greet", 200, "Hello World 2")
+    tester.modifyFile(
+      tester.workspacePath / "app" / "src" / "App.scala",
+      _ => os.read(resourceDir / "changes" / "App.scala.1")
     )
     val greetReloaded =
       runUntil("http://localhost:9000/greet_reloaded", 200, "World Hello 2")
@@ -160,7 +162,7 @@ class IntegrationTests extends AnyFunSuite with RequestMaker {
     process.join()
     tester.close()
 
-    assert(greet && greetReloaded)
+    assert(greet && greetResourceReloaded && greetReloaded)
   }
 
   test("grpc-scalapb") {
@@ -302,11 +304,6 @@ class IntegrationTests extends AnyFunSuite with RequestMaker {
       "Multi-Hi".getBytes("UTF-8")
     )
     tester.modifyFile(
-      tester.workspacePath / "project-a" / "src" / "App.scala",
-      _ =>
-        os.read(resourceDir / "changes" / "project-a" / "src" / "App.scala.1")
-    )
-    tester.modifyFile(
       tester.workspacePath / "project-b" / "src" / "Greeting.scala",
       _ =>
         os.read(
@@ -319,7 +316,7 @@ class IntegrationTests extends AnyFunSuite with RequestMaker {
       "greeter.Greeter",
       "Greet",
       Array.emptyByteArray,
-      "Multi-Yo!".getBytes("UTF-8")
+      "Multi-Yo".getBytes("UTF-8")
     )
 
     tester.close()

--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -1,5 +1,7 @@
 package me.seroperson.reload.live.mill
 
+import java.io.File
+import java.nio.file.{Path => JPath}
 import java.util.function.Supplier
 import me.seroperson.reload.live.runner.CompileResult
 import me.seroperson.reload.live.runner.CompileResult.CompileFailure
@@ -8,9 +10,8 @@ import me.seroperson.reload.live.runner.DevServerRunner
 import me.seroperson.reload.live.runner.StartParams
 import me.seroperson.reload.live.settings.DevServerSettings
 import mill.*
+import mill.api.BuildCtx
 import mill.api.Evaluator
-import mill.api.Task.Simple
-import mill.api.TaskCtx
 import mill.api.daemon.Result
 import mill.javalib.Dep
 import mill.javalib.JavaModule
@@ -46,6 +47,33 @@ trait LiveReloadModule extends JavaModule {
 
   def livePropagateEnv: Task[Map[String, String]] = Task.Anon {
     Map()
+  }
+
+  private def liveMonitoredFiles: Task[Seq[File]] = {
+    val monitoredInputTasks =
+      transitiveRunModuleDeps.flatMap(module =>
+        Seq(module.sources, module.resources)
+      )
+    val monitoredInputs = Task.sequence(monitoredInputTasks)
+
+    Task.Anon {
+      val outputRoot =
+        (BuildCtx.workspaceRoot / "out").toIO.getCanonicalFile.toPath
+      val monitoredPaths = monitoredInputs().flatten
+        .map(_.path.toIO.getCanonicalFile.toPath)
+        .filterNot(path => path.startsWith(outputRoot))
+        .filter(path => path.toFile.exists())
+        .distinct
+        .sorted
+        .foldLeft(List.empty[JPath]) { (result, next) =>
+          result.headOption match {
+            case Some(previous) if next.startsWith(previous) => result
+            case _                                           => next :: result
+          }
+        }
+
+      monitoredPaths.reverse.map(_.toFile)
+    }
   }
 
   def liveHookBundle: Task[Option[HookBundle]] = Task.Anon {
@@ -141,7 +169,8 @@ trait LiveReloadModule extends JavaModule {
       /* dependencyClasspath */ resolvedRunMvnDeps()
         .map(_.path.toIO)
         .asJava,
-      /* monitoredFiles */ sources().map(_.path.toIO).asJava,
+      /* monitoredFiles */
+      liveMonitoredFiles().asJava,
       /* mainClassName */ mainClassName,
       /* internalMainClassName */ finalMainClass(),
       liveStartupHooks().asJava,


### PR DESCRIPTION
## Summary

Fix Mill `liveReloadRun` so resource-only edits and transitive module source/resource edits are monitored for live reloads.

The previous implementation compiled `runClasspath`, but only passed the current module's `sources()` to the file watcher. This meant changes that affected `runClasspath`, such as `resources` or a runtime dependency module's sources, did not mark the dev server as changed.

Fixes: N/A - no GitHub issue has been filed for this candidate yet.

AI assistance: prepared with Codex and verified with the commands below.

## How was it tested?

- New regression coverage in `mill/integration/src/IntegrationTests.scala`
  - `http4s-with-resources` now edits only `app/resources/application.conf` first and asserts the app reloads with the new config value.
  - `grpc-multiproject` now edits only `project-b/src/Greeting.scala` and asserts the dependent app reloads.
- `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' timeout 10m just test-mill`
- `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' timeout 10m just code-format-check-all`
- Earlier focused checks:
  - `./millw --no-server mill-live-reload.publishLocal`
  - `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' ./millw --no-server mill-live-reload.integration.testOnly me.seroperson.reload.live.mill.test.IntegrationTests -- -z http4s-with-resources`
  - `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' ./millw --no-server mill-live-reload.integration.testOnly me.seroperson.reload.live.mill.test.IntegrationTests -- -z grpc-multiproject`
  - `git diff --check`

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework (not applicable)
- [x] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support (not applicable)
- [x] No unrelated files were reformatted or refactored
