### PR TITLE
fix: watch sbt generated sources

### DIFF
--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/Commands.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/Commands.scala
@@ -169,7 +169,8 @@ private[sbt] object Commands {
 
     Def.task {
       val allDirectories =
-        (unmanagedSourceDirectories ?? Nil).all(filter).value.flatten ++
+        sourceDirectory.all(filter).value ++
+          (unmanagedSourceDirectories ?? Nil).all(filter).value.flatten ++
           (unmanagedResourceDirectories ?? Nil).all(filter).value.flatten
 
       val existingDirectories = allDirectories.filter(_.exists)

--- a/sbt/src/test/resources/grpc-scalapb/changes/greeter.proto.1
+++ b/sbt/src/test/resources/grpc-scalapb/changes/greeter.proto.1
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+service Greeter {
+  rpc SayHello (HelloRequest) returns (HelloReply) {}
+}
+
+message HelloRequest {
+  string name = 1;
+}
+
+message HelloReply {
+  string message = 2;
+}

--- a/sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala
@@ -177,6 +177,36 @@ class GrpcLiveReloadSpec extends LiveReloadBase {
     }
   }
 
+  // sbt-protoc is only available for sbt 1.x
+  testEach(
+    "grpc-scalapb - live reload on protobuf source change",
+    versions = Seq("1.12.3")
+  ) { sbtVersion =>
+    withRunner("grpc-scalapb", sbtVersion) { (runner, proxyPort) =>
+      runner.run("bgRun")
+      // response: HelloReply(message = "World Hello!") encoded as field 1
+      verifyGrpc(
+        "Greeter",
+        "SayHello",
+        "0a0c48656c6c6f20576f726c6421",
+        "0a0c576f726c642048656c6c6f21",
+        proxyPort
+      )
+      runner.copyFile(
+        "changes/greeter.proto.1",
+        "src/main/protobuf/greeter.proto"
+      )
+      // response: same Scala field, but regenerated protobuf uses field 2
+      verifyGrpc(
+        "Greeter",
+        "SayHello",
+        "0a0c48656c6c6f20576f726c6421",
+        "120c576f726c642048656c6c6f21",
+        proxyPort
+      )
+    }
+  }
+
   private def listServicesViaReflection(port: Int): Set[String] = {
     val channel =
       ManagedChannelBuilder.forAddress("localhost", port).usePlaintext().build()


### PR DESCRIPTION
## Summary

Fixes sbt live reload not noticing generated-source inputs under the standard source root, such as `src/main/protobuf`.

The sbt watcher now includes each dependency project's `Compile / sourceDirectory` root in addition to unmanaged source and resource directories, so edits to generator inputs under `src/main` can trigger the existing reload compile path.

## How was it tested?

- New regression test - `sbt/src/test/scala/me/seroperson/reload/live/GrpcLiveReloadSpec.scala` adds `grpc-scalapb - live reload on protobuf source change`, which changes only `src/main/protobuf/greeter.proto` and verifies the regenerated gRPC response wire format.
- `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' XDG_RUNTIME_DIR=/tmp timeout 10m sbt --server --no-server quickLocalPublish`
- `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' XDG_RUNTIME_DIR=/tmp timeout 10m sbt --server --no-server "sbtLiveReload / Test / testOnly me.seroperson.reload.live.GrpcLiveReloadSpec -- -z protobuf"`
- `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' timeout 10m just code-format-check-all`
- `git diff --check`

Attempted broader sbt verification with `JDK_JAVA_OPTIONS='--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED' XDG_RUNTIME_DIR=/tmp timeout 15m sbt --server --no-server test`, but stopped it after unrelated Cask fixture/environment failures while resolving `org/slf4j/slf4j-api` from the local Maven cache and then timing out before the Cask app was reachable. The focused protobuf regression above passed.

GitHub Actions CI was created for commit `3d0b4b234cb29a3255656feb28bdac6303a4eeda`, but GitHub completed it as `action_required` before starting jobs: https://github.com/seroperson/jvm-live-reload/actions/runs/27205707960. The API approval endpoint returned `403 Must have admin rights to Repository`, so I cannot trigger the full upstream checklist from this fork token.

## Checklist

- [ ] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework (not applicable)
- [x] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support (not applicable)
- [x] No unrelated files were reformatted or refactored
