### PR TITLE
fix: avoid busy-loop in blocking run when stdin is non-interactive

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
@@ -150,9 +150,23 @@ public final class DevServerRunner {
       try (var terminal = terminalBuilder.build()) {
         var reader = terminal.reader();
         while (devServer.isRunning()) {
+          int input = reader.read(100);
           // 10: Enter
-          if (reader.read(100) == 10) {
+          if (input == 10) {
             break;
+          }
+          if (input == -1) {
+            // EOF: stdin is closed / non-interactive (CI, piped input, nohup,
+            // some IDE run consoles). read(100) returns immediately in this case,
+            // so reading in a tight loop would peg a CPU core at 100%. There is no
+            // console to read Enter from, so block without busy-spinning until the
+            // server stops or this thread is interrupted (e.g. Ctrl-C / SIGTERM).
+            try {
+              Thread.sleep(200L);
+            } catch (InterruptedException e) {
+              Thread.currentThread().interrupt();
+              break;
+            }
           }
         }
       }


### PR DESCRIPTION
## What

`DevServerRunner.runBlocking` keeps the dev server in the foreground until Enter is pressed, looping on a jline terminal reader. `reader.read(100)` returns `READ_EXPIRED` (-2) after the timeout when interactive (cheap idle), but returns `EOF` (-1) **immediately every iteration** when stdin is non-interactive (CI, piped input, `nohup`, some IDE consoles). The loop only broke on `10` (Enter), so on EOF it spun as fast as the CPU allowed - pegging a core at ~100% for the server's whole lifetime - and "press Enter to stop" was impossible.

This affects the blocking path used by `sbt run` and `mill liveReloadRun` (Gradle uses the deployment-handle path and is unaffected).

## Change

In the read loop, capture the read result once and handle EOF explicitly: on `-1`, block in a short interrupt-aware `Thread.sleep` instead of busy-spinning, so the server keeps serving without burning CPU until the process is interrupted (Ctrl-C / SIGTERM closes the dev server via the surrounding try-with-resources) or the server stops on its own. Enter still stops it when a console is present, and the interactive idle path (`-2`) is unchanged.

Fixes #66