### PR TITLE
fix: make mill hook-bundle detection deterministic

### DIFF
--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -52,20 +52,20 @@ trait LiveReloadModule extends JavaModule {
     if (liveServerType() == GrpcServerType) {
       Some(GrpcAppHookBundle)
     } else {
-      runClasspath().collectFirst {
-        case lib
-            if lib.path.toIO.getName.startsWith(
-              "zio-http"
-            ) || lib.path.toIO.getName.startsWith("zio") =>
-          ZioAppHookBundle
-        case lib if lib.path.toIO.getName.startsWith("cask") =>
-          CaskAppHookBundle
-        case lib
-            if lib.path.toIO.getName.startsWith(
-              "http4s"
-            ) || lib.path.toIO.getName.startsWith("cats-effect") =>
-          IoAppHookBundle
-      }
+      val jarNames = runClasspath().map(_.path.toIO.getName)
+      def has(prefix: String): Boolean = jarNames.exists(_.startsWith(prefix))
+      // Decide by framework precedence rather than classpath order: markers for
+      // multiple frameworks can legitimately coexist on a single classpath
+      // (zio-interop-cats, or a standalone zio-json/zio-prelude in an http4s
+      // app), so collectFirst over runClasspath() would pick a bundle based on
+      // whichever marker jar happens to come first. Anchor on the unambiguous
+      // web-framework jar first, then fall back to the broad prefixes.
+      if (has("zio-http")) Some(ZioAppHookBundle)
+      else if (has("http4s")) Some(IoAppHookBundle)
+      else if (has("cask")) Some(CaskAppHookBundle)
+      else if (has("zio")) Some(ZioAppHookBundle)
+      else if (has("cats-effect")) Some(IoAppHookBundle)
+      else None
     }
   }
 

--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -54,12 +54,6 @@ trait LiveReloadModule extends JavaModule {
     } else {
       val jarNames = runClasspath().map(_.path.toIO.getName)
       def has(prefix: String): Boolean = jarNames.exists(_.startsWith(prefix))
-      // Decide by framework precedence rather than classpath order: markers for
-      // multiple frameworks can legitimately coexist on a single classpath
-      // (zio-interop-cats, or a standalone zio-json/zio-prelude in an http4s
-      // app), so collectFirst over runClasspath() would pick a bundle based on
-      // whichever marker jar happens to come first. Anchor on the unambiguous
-      // web-framework jar first, then fall back to the broad prefixes.
       if (has("zio-http")) Some(ZioAppHookBundle)
       else if (has("http4s")) Some(IoAppHookBundle)
       else if (has("cask")) Some(CaskAppHookBundle)


### PR DESCRIPTION
## What

The mill plugin auto-detects the application framework in `LiveReloadModule.liveHookBundle` with `collectFirst` over `runClasspath()`, using broad bare prefixes `startsWith("zio")` and `startsWith("cats-effect")`. `collectFirst` returns the bundle for the **first jar that matches any case**, so selection depends on arbitrary classpath order, not framework precedence. When a classpath carries markers for two frameworks - which is common - the wrong bundle is chosen:

- A ZIO app using `zio-interop-cats` pulls `cats-effect-*.jar` ? may be detected as a cats-effect IOApp.
- An http4s/cats-effect app using a standalone `zio-*` lib (`zio-json`, `zio-prelude`) ? `startsWith("zio")` matches ? may be detected as ZIO.

The wrong startup/shutdown hooks are then installed, so the framework-specific shutdown hook never runs and reload doesn't cleanly stop the app. The sbt plugin avoids this by matching only the unambiguous web-framework markers (`zio-http`/`http4s`/`cask`); mill should be consistent.

## Change

Replace the order-dependent `collectFirst` with deterministic, precedence-based detection over the whole classpath: anchor on the unambiguous web-framework marker first (`zio-http` -> ZIO, `http4s` -> cats-effect, `cask` -> Cask), then fall back to the broad `zio` / `cats-effect` prefixes. The result is now independent of classpath ordering. `None` is still returned when no marker matches.

Fixes #68