### PR TITLE
fix: don't hang or deadlock when the main class fails to load

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
@@ -129,14 +129,29 @@ public abstract class BaseDevServerStart<S> implements ReloadableServer {
                 } catch (ClassNotFoundException
                     | NoSuchMethodException
                     | IllegalAccessException e) {
+                  // Could not load/locate/access main(String[]). Record the
+                  // failure so the startup health-check hook aborts the reload via
+                  // AppFailureRegistry.throwIfFailed. Do NOT call stopInternal()
+                  // here: it is synchronized on the same monitor the reload thread
+                  // already holds while running the startup hooks, so calling it
+                  // from this thread would deadlock.
                   logger.error("Failed to invoke main method on " + mainClass, e);
-                  stopInternal();
-                  throw new RuntimeException(e);
+                  AppFailureRegistry.record(Thread.currentThread(), e);
                 } catch (InvocationTargetException e) {
                   // Don't log InterruptedException, as likely they're intended
                   if (!(e.getCause() instanceof InterruptedException)) {
                     logger.error("Error in application main thread", e);
                     AppFailureRegistry.record(Thread.currentThread(), e.getCause());
+                  }
+                } catch (Throwable t) {
+                  // e.g. ExceptionInInitializerError / NoClassDefFoundError raised
+                  // while loading or initializing the main class. These are not
+                  // wrapped in InvocationTargetException, so without this branch
+                  // they would escape uncaught on the app thread and the startup
+                  // hook would poll forever.
+                  if (!(t instanceof InterruptedException)) {
+                    logger.error("Failed to start " + mainClass, t);
+                    AppFailureRegistry.record(Thread.currentThread(), t);
                   }
                 }
               },


### PR DESCRIPTION
## What

`BaseDevServerStart.startInternal` runs the application's `main` on a dedicated thread and is supposed to surface failures so the startup health-check hook can abort the reload. Only the `InvocationTargetException` path (main() throwing after a successful invoke, #26/#36) did that correctly. Three other failure modes - all hit when the main class can't actually be run - were broken:

1. **Deadlock:** the `ClassNotFoundException | NoSuchMethodException | IllegalAccessException` branch called the `synchronized` `stopInternal()` from the application thread, while the reload thread still holds that monitor running the startup hooks ? app thread blocks forever, hook polls forever.
2. **Failure never recorded:** that branch never recorded to `AppFailureRegistry`, so the startup hook had no way to learn the app was dead and polled indefinitely.
3. **Linkage/init errors uncaught:** invoking `main` triggers class init; a throwing static initializer surfaces as `ExceptionInInitializerError` and a missing runtime jar as `NoClassDefFoundError` - neither is wrapped in `InvocationTargetException`, so they escaped uncaught on the app thread and the server hung.

Net symptom: a typo'd main class, wrong `main` signature, throwing static initializer, or missing dependency wedges the dev server on the first request (kill -9) instead of failing fast.

## Change

- Load/lookup failures now `AppFailureRegistry.record(...)` instead of calling the synchronized `stopInternal()` from the app thread (removes the deadlock). The startup hook's `throwIfFailed` then aborts the reload, and `startInternal`'s own `catch (RuntimeException | Error)` performs cleanup on the reload thread.
- Added a `catch (Throwable t)` that records `ExceptionInInitializerError` / `NoClassDefFoundError` (guarding `InterruptedException`), so class-loading/initialization failures abort cleanly instead of hanging.

Distinct from #26 / #36, which cover `main()` throwing after a successful invoke.

Fixes #70