### PR TITLE
fix: reuse the gRPC health-check channel across polls

### DIFF
--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckHook.java
@@ -21,30 +21,43 @@ import me.seroperson.reload.live.settings.DevServerSettings;
 /**
  * Base interface for hooks that probe the GRPC health checking protocol of the target server.
  *
- * <p>Each call to {@link #isHealthy} opens a short-lived channel, issues a unary {@code Check}
- * against {@code grpc.health.v1.Health}, and shuts down the channel. The {@code service} field of
- * the request can be configured via {@link DevServerSettings#getGrpcHealthService()}; an empty
- * string queries the overall server health as specified by the protocol.
+ * <p>A single {@link ManagedChannel} is opened once via {@link #openChannel} for the duration of a
+ * polling loop and reused across every {@link #checkHealth} probe, then released with {@link
+ * #closeChannel}. A channel is a heavyweight, long-lived object (name resolution, connection pool,
+ * backoff), so it must not be recreated per poll. The {@code service} field of the request can be
+ * configured via {@link DevServerSettings#getGrpcHealthService()}; an empty string queries the
+ * overall server health as specified by the protocol.
  */
 interface GrpcHealthCheckHook extends Hook {
 
   /**
-   * Probes the target GRPC server for health.
+   * Opens a channel to the target GRPC server. Reuse the returned channel for every {@link
+   * #checkHealth} call in a polling loop and release it with {@link #closeChannel} when done.
    *
-   * @param logger build logger
-   * @param settings dev server settings (host, port, service name, TLS flag)
-   * @return 1 SERVING, 0 NOT_SERVING/UNKNOWN, -1 connection error, 404 health service not
-   *     implemented by the target
+   * @param settings dev server settings (host, port, TLS flag)
+   * @return a new managed channel to the target server
    */
-  default int isHealthy(BuildLogger logger, DevServerSettings settings) {
+  default ManagedChannel openChannel(DevServerSettings settings) {
     var host = settings.getGrpcHost();
     var port = settings.getGrpcPort();
-    var service = settings.getGrpcHealthService();
     ChannelCredentials credentials =
         settings.isGrpcTargetTls()
             ? buildTlsCredentials(settings.getGrpcTargetTlsTrust())
             : InsecureChannelCredentials.create();
-    ManagedChannel channel = Grpc.newChannelBuilderForAddress(host, port, credentials).build();
+    return Grpc.newChannelBuilderForAddress(host, port, credentials).build();
+  }
+
+  /**
+   * Probes the target GRPC server for health over an already-open channel.
+   *
+   * @param channel the channel to probe over (see {@link #openChannel})
+   * @param logger build logger
+   * @param settings dev server settings (service name)
+   * @return 1 SERVING, 0 NOT_SERVING/UNKNOWN, -1 connection error, 404 health service not
+   *     implemented by the target
+   */
+  default int checkHealth(ManagedChannel channel, BuildLogger logger, DevServerSettings settings) {
+    var service = settings.getGrpcHealthService();
     try {
       var stub = HealthGrpc.newBlockingStub(channel).withDeadlineAfter(1, TimeUnit.SECONDS);
       var request =
@@ -60,13 +73,20 @@ interface GrpcHealthCheckHook extends Hook {
     } catch (Exception ex) {
       logger.error("Error during GRPC health check", ex);
       return -1;
-    } finally {
-      channel.shutdownNow();
-      try {
-        channel.awaitTermination(1, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
+    }
+  }
+
+  /**
+   * Shuts down a channel opened by {@link #openChannel}.
+   *
+   * @param channel the channel to release
+   */
+  static void closeChannel(ManagedChannel channel) {
+    channel.shutdownNow();
+    try {
+      channel.awaitTermination(1, TimeUnit.SECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckShutdownHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckShutdownHook.java
@@ -25,10 +25,11 @@ public class GrpcHealthCheckShutdownHook implements GrpcHealthCheckHook {
 
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    var channel = openChannel(settings);
     try {
       while (true) {
         logger.debug("Waiting for the GRPC health-check to stop returning SERVING ...");
-        var response = isHealthy(logger, settings);
+        var response = checkHealth(channel, logger, settings);
         logger.debug("Response from a health-check: " + response);
         if (response == 1) {
           Thread.sleep(50L);
@@ -43,6 +44,8 @@ public class GrpcHealthCheckShutdownHook implements GrpcHealthCheckHook {
       }
     } catch (InterruptedException e) {
       // Don't print anything, just quit
+    } finally {
+      GrpcHealthCheckHook.closeChannel(channel);
     }
   }
 }

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckStartupHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckStartupHook.java
@@ -26,11 +26,12 @@ public class GrpcHealthCheckStartupHook implements GrpcHealthCheckHook {
 
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    var channel = openChannel(settings);
     try {
       while (true) {
         AppFailureRegistry.throwIfFailed(th);
         logger.debug("Waiting for the GRPC health-check to return SERVING ...");
-        var response = isHealthy(logger, settings);
+        var response = checkHealth(channel, logger, settings);
         if (response == 1) {
           return;
         } else if (response == 0 || response == -1) {
@@ -48,6 +49,8 @@ public class GrpcHealthCheckStartupHook implements GrpcHealthCheckHook {
       }
     } catch (InterruptedException e) {
       // Don't print anything, just quit
+    } finally {
+      GrpcHealthCheckHook.closeChannel(channel);
     }
   }
 }


### PR DESCRIPTION
## What

The gRPC health-check probe (`GrpcHealthCheckHook.isHealthy`) built a brand-new `ManagedChannel`, issued one `Check`, and `shutdownNow()`-ed it on **every** poll - and both the startup and shutdown hooks call it in a 50ms poll loop. A `ManagedChannel` is a heavyweight, long-lived object (name resolution, connection pool, backoff) that gRPC expects you to reuse across calls. Recreating it per poll causes:

- **Connection churn:** every poll re-runs name resolution and a fresh TCP + HTTP/2 handshake, then tears it down - hundreds of create/destroy cycles during a slow startup.
- **Slower / flakier readiness detection:** each poll uses a *cold* channel that must connect *and* round-trip within the hard 1s deadline, so under load a cold connect can blow the deadline (`DEADLINE_EXCEEDED` -> `-1`), reporting "not ready" even when the server is serving and delaying the first request after a reload.

## Change

Split the probe so the channel lifecycle is owned by the polling loop instead of a single RPC:

- `openChannel(settings)` builds the channel once,
- `checkHealth(channel, logger, settings)` probes over the passed-in channel (no create/destroy),
- `static closeChannel(channel)` shuts it down.

Each hook (`GrpcHealthCheckStartupHook`, `GrpcHealthCheckShutdownHook`) now opens the channel once before its loop, reuses it across polls, and closes it in a `finally`. A fresh channel is still created per `hook()` invocation (i.e. per reload generation), so there is no stale-connection-across-reloads concern; the reuse is only within one poll loop.

Fixes #72