### PR TITLE
fix: bound shutdown health-check hooks with timeout

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckShutdownHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/HealthCheckShutdownHook.java
@@ -26,13 +26,20 @@ public abstract class HealthCheckShutdownHook implements HealthCheckHook {
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
     try {
+      long deadlineMs = System.currentTimeMillis() + settings.getThreadInterruptTimeoutMs();
       while (true) {
+        if (System.currentTimeMillis() > deadlineMs) {
+          throw new UnrecoverableException(
+              "Shutdown health-check did not report failure within "
+                  + settings.getThreadInterruptTimeoutMs()
+                  + "ms; the old application may still be running.");
+        }
         logger.debug("Waiting for the health-check to return failure ...");
         var path = settings.getHealthCheckPath();
         var healthResponse =
             isHealthy(logger, path, settings.getHttpHost(), settings.getHttpPort());
         if (healthResponse == 1) {
-          // success
+          // success — server still up
           Thread.sleep(50L);
         } else if (healthResponse == 0) {
           // non-success response, but not an exception

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckShutdownHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckShutdownHook.java
@@ -26,7 +26,14 @@ public class GrpcHealthCheckShutdownHook implements GrpcHealthCheckHook {
   @Override
   public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
     try {
+      long deadlineMs = System.currentTimeMillis() + settings.getThreadInterruptTimeoutMs();
       while (true) {
+        if (System.currentTimeMillis() > deadlineMs) {
+          throw new UnrecoverableException(
+              "GRPC shutdown health-check did not stop reporting SERVING within "
+                  + settings.getThreadInterruptTimeoutMs()
+                  + "ms; the old application may still be running.");
+        }
         logger.debug("Waiting for the GRPC health-check to stop returning SERVING ...");
         var response = isHealthy(logger, settings);
         logger.debug("Response from a health-check: " + response);


### PR DESCRIPTION
## What

`HealthCheckShutdownHook` and `GrpcHealthCheckShutdownHook` loop `while (true)` waiting for the old application to stop responding. If the app hangs in shutdown and never closes its socket, the hook polls forever — the dev server is then stuck and can only be killed with `kill -9`.

This is the teardown-side twin of the startup-hook timeout already applied to the startup hooks and `ThreadInterruptShutdownHook` (commit 80352bf).

## How

Add a deadline using the existing `live.reload.thread.interrupt.timeout` setting (default 15 s). When the deadline is exceeded an `UnrecoverableException` is thrown so the reload aborts with a clear message instead of hanging indefinitely.

No new settings key; the thread-interrupt timeout is already the user-facing knob for "how long to wait for the application during a reload cycle".

## Testing

The fix follows exactly the same pattern as the `ThreadInterruptShutdownHook` deadline added in #20. No functional-test fixture currently covers a hung-on-shutdown app, so I validated the logic by code review against the existing pattern.

Fixes #48

---
_I used an AI assistant for this change and confirmed the logic against the existing shutdown-hook patterns before submitting._