### PR TITLE
fix: restore env vars and shutdown hooks when DevServerWrapper.start() fails

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerWrapper.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerWrapper.java
@@ -44,7 +44,13 @@ public class DevServerWrapper implements ReloadableServer {
     ShutdownHook.logShutdownHooks(buildSystemShutdownHooks, logger);
     ShutdownHook.unregisterShutdownHooks(buildSystemHookThreadIds);
 
-    server.start();
+    try {
+      server.start();
+    } catch (RuntimeException | Error e) {
+      Environment.setEnv(initialEnv);
+      ShutdownHook.setShutdownHooks(new IdentityHashMap<>(buildSystemShutdownHooks));
+      throw e;
+    }
   }
 
   @Override


### PR DESCRIPTION
## What

`DevServerWrapper.start()` mutates the host build JVM in two ways before it calls `server.start()`:

1. Injects live-reload env vars via `Environment.putEnv()`
2. Snapshots and **unregisters** the build system's own shutdown hooks via `ShutdownHook.unregisterShutdownHooks()`

If `server.start()` subsequently throws, those mutations are never rolled back:
- The propagated env vars stay in the build process environment for the rest of the build session.
- The build system's shutdown hooks remain unregistered, potentially preventing a clean JVM exit.

## How

Wrap `server.start()` in a `try/catch (RuntimeException | Error)` that invokes the same two cleanup calls already present in `close()` — `Environment.setEnv(initialEnv)` and `ShutdownHook.setShutdownHooks(...)` — before re-throwing. A failed start now leaves the build JVM in exactly the same state as before `start()` was called.

## Testing

Logic confirmed by code review against the existing `close()` cleanup path (lines 69-76). No new test fixture added; the fix is a single try/catch wrapping one call.

Fixes #11

---
_I used an AI assistant for this change and confirmed the fix against the existing `close()` cleanup path before submitting._