### PR TITLE
fix: reuse ManagedChannel across polls in gRPC health-check hooks

### DIFF
--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckHook.java
@@ -19,32 +19,34 @@ import me.seroperson.reload.live.hook.Hook;
 import me.seroperson.reload.live.settings.DevServerSettings;
 
 /**
- * Base interface for hooks that probe the GRPC health checking protocol of the target server.
+ * Base class for hooks that probe the GRPC health checking protocol of the target server.
  *
- * <p>Each call to {@link #isHealthy} opens a short-lived channel, issues a unary {@code Check}
- * against {@code grpc.health.v1.Health}, and shuts down the channel. The {@code service} field of
- * the request can be configured via {@link DevServerSettings#getGrpcHealthService()}; an empty
- * string queries the overall server health as specified by the protocol.
+ * <p>A single {@link ManagedChannel} is created on the first {@link #isHealthy} call within a
+ * {@link #hook} invocation and reused for all subsequent polls. Subclasses must call {@link
+ * #closeChannel()} — typically in a {@code finally} block — when their {@code hook()} method
+ * returns so the channel is shut down promptly.
+ *
+ * <p>The {@code service} field of the health-check request can be configured via {@link
+ * DevServerSettings#getGrpcHealthService()}; an empty string queries the overall server health as
+ * specified by the protocol.
  */
-interface GrpcHealthCheckHook extends Hook {
+abstract class GrpcHealthCheckHook implements Hook {
+
+  private ManagedChannel channel;
 
   /**
-   * Probes the target GRPC server for health.
+   * Probes the target GRPC server for health, reusing the same channel across calls.
    *
    * @param logger build logger
    * @param settings dev server settings (host, port, service name, TLS flag)
    * @return 1 SERVING, 0 NOT_SERVING/UNKNOWN, -1 connection error, 404 health service not
    *     implemented by the target
    */
-  default int isHealthy(BuildLogger logger, DevServerSettings settings) {
-    var host = settings.getGrpcHost();
-    var port = settings.getGrpcPort();
+  protected final int isHealthy(BuildLogger logger, DevServerSettings settings) {
+    if (channel == null) {
+      channel = buildChannel(settings);
+    }
     var service = settings.getGrpcHealthService();
-    ChannelCredentials credentials =
-        settings.isGrpcTargetTls()
-            ? buildTlsCredentials(settings.getGrpcTargetTlsTrust())
-            : InsecureChannelCredentials.create();
-    ManagedChannel channel = Grpc.newChannelBuilderForAddress(host, port, credentials).build();
     try {
       var stub = HealthGrpc.newBlockingStub(channel).withDeadlineAfter(1, TimeUnit.SECONDS);
       var request =
@@ -60,14 +62,31 @@ interface GrpcHealthCheckHook extends Hook {
     } catch (Exception ex) {
       logger.error("Error during GRPC health check", ex);
       return -1;
-    } finally {
-      channel.shutdownNow();
+    }
+  }
+
+  /** Shuts down the shared channel. Must be called once the polling loop exits. */
+  protected final void closeChannel() {
+    ManagedChannel ch = channel;
+    channel = null;
+    if (ch != null) {
+      ch.shutdownNow();
       try {
-        channel.awaitTermination(1, TimeUnit.SECONDS);
+        ch.awaitTermination(1, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }
     }
+  }
+
+  private ManagedChannel buildChannel(DevServerSettings settings) {
+    ChannelCredentials credentials =
+        settings.isGrpcTargetTls()
+            ? buildTlsCredentials(settings.getGrpcTargetTlsTrust())
+            : InsecureChannelCredentials.create();
+    return Grpc.newChannelBuilderForAddress(
+            settings.getGrpcHost(), settings.getGrpcPort(), credentials)
+        .build();
   }
 
   private static ChannelCredentials buildTlsCredentials(String trustPath) {

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckShutdownHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckShutdownHook.java
@@ -11,7 +11,7 @@ import me.seroperson.reload.live.settings.DevServerSettings;
  * becomes unreachable, confirming the old generation is no longer answering before a new one is
  * started.
  */
-public class GrpcHealthCheckShutdownHook implements GrpcHealthCheckHook {
+public class GrpcHealthCheckShutdownHook extends GrpcHealthCheckHook {
 
   @Override
   public String description() {
@@ -43,6 +43,8 @@ public class GrpcHealthCheckShutdownHook implements GrpcHealthCheckHook {
       }
     } catch (InterruptedException e) {
       // Don't print anything, just quit
+    } finally {
+      closeChannel();
     }
   }
 }

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckStartupHook.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/hook/GrpcHealthCheckStartupHook.java
@@ -12,7 +12,7 @@ import me.seroperson.reload.live.settings.DevServerSettings;
  * reports {@code SERVING}, ensuring the new generation of the application is ready before requests
  * are accepted.
  */
-public class GrpcHealthCheckStartupHook implements GrpcHealthCheckHook {
+public class GrpcHealthCheckStartupHook extends GrpcHealthCheckHook {
 
   @Override
   public String description() {
@@ -48,6 +48,8 @@ public class GrpcHealthCheckStartupHook implements GrpcHealthCheckHook {
       }
     } catch (InterruptedException e) {
       // Don't print anything, just quit
+    } finally {
+      closeChannel();
     }
   }
 }


### PR DESCRIPTION
## What

`GrpcHealthCheckHook.isHealthy()` previously created a fresh `ManagedChannel` on every call, issued a single `Check` RPC, then immediately called `shutdownNow()` + `awaitTermination()`. During a startup or graceful shutdown the hook polls repeatedly, so a new channel (and its underlying OS socket and thread pool) was built and destroyed on every single poll — churning connections and slowing readiness detection.

## How

Convert `GrpcHealthCheckHook` from an interface to an abstract class that **lazily creates one `ManagedChannel`** on the first `isHealthy()` call and reuses it for all subsequent polls within the same `hook()` invocation. Both `GrpcHealthCheckStartupHook` and `GrpcHealthCheckShutdownHook` now `extend` the abstract class and call `closeChannel()` in a `finally` block so the channel is always released when the polling loop exits (normally, via exception, or via `InterruptedException`).

## Public API impact

None. The two concrete hook classes remain `public`; only their supertype declaration changes from `implements GrpcHealthCheckHook` to `extends GrpcHealthCheckHook`. The `isHealthy(BuildLogger, DevServerSettings)` method is now `protected final` on the abstract class instead of a `default` method on an interface.

## Testing

Validated by code review: the channel is created once per `hook()` call and closed in `finally` regardless of exit path. Existing GRPC functional tests cover the happy path end-to-end.

Fixes #72

---
_I used an AI assistant for this change and verified the channel lifecycle (create-once, close-in-finally) before submitting._