### PR TITLE
fix: eliminate ManagedChannel leak race in ReloadableGrpcProxyHandler

### DIFF
--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/ReloadableGrpcProxyHandler.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/ReloadableGrpcProxyHandler.java
@@ -59,15 +59,25 @@ class ReloadableGrpcProxyHandler {
   /**
    * Gets the current channel, creating one if necessary.
    *
+   * <p>Uses compare-and-set to avoid a race where two concurrent callers both observe a null or
+   * shut-down channel, both call {@link #createChannel()}, and then one of the freshly built
+   * channels is silently overwritten and leaked.
+   *
    * @return the managed channel to the target server
    */
   public Channel getChannel() {
-    ManagedChannel channel = channelRef.get();
-    if (channel == null || channel.isShutdown() || channel.isTerminated()) {
-      channel = createChannel();
-      channelRef.set(channel);
+    ManagedChannel existing = channelRef.get();
+    if (existing != null && !existing.isShutdown() && !existing.isTerminated()) {
+      return existing;
     }
-    return channel;
+    ManagedChannel candidate = createChannel();
+    if (channelRef.compareAndSet(existing, candidate)) {
+      return candidate;
+    }
+    // Another thread won the race — discard the channel we just built and use theirs.
+    candidate.shutdownNow();
+    ManagedChannel winner = channelRef.get();
+    return winner != null ? winner : candidate;
   }
 
   /**


### PR DESCRIPTION
## What

`ReloadableGrpcProxyHandler.getChannel()` read `channelRef`, and if the stored channel was `null` or already shut down, called `createChannel()` and wrote the result back with a plain `AtomicReference.set()`. Under concurrent GRPC traffic two callers could both observe the null/shutdown state simultaneously, both build a new `ManagedChannel`, and then one write would silently overwrite the other — leaking the first channel and its underlying OS socket and thread resources for the lifetime of the process.

## How

Replace the read-check-set sequence with a compare-and-set:

```java
ManagedChannel candidate = createChannel();
if (channelRef.compareAndSet(existing, candidate)) {
    return candidate;
}
// Another thread won the race — shut down ours and use theirs.
candidate.shutdownNow();
```

Exactly one caller wins the CAS and installs its channel; every other concurrent caller shuts down the channel it built and returns the winner's instead. No additional locking needed.

## Testing

Logic verified by code review against `AtomicReference.compareAndSet` semantics. Existing GRPC functional tests cover concurrent request routing end-to-end.

Fixes #17

---
_I used an AI assistant for this change and reviewed the CAS semantics before submitting._