### PR TITLE
fix: avoid busy-spin in runBlocking when stdin is non-interactive

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerRunner.java
@@ -159,9 +159,15 @@ public final class DevServerRunner {
       try (var terminal = terminalBuilder.build()) {
         var reader = terminal.reader();
         while (devServer.isRunning()) {
-          // 10: Enter
-          if (reader.read(100) == 10) {
+          int ch = reader.read(100);
+          if (ch == 10) {
+            // Enter pressed — stop the server
             break;
+          }
+          if (ch < 0) {
+            // EOF: stdin is non-interactive (pipe, /dev/null, CI). Avoid a
+            // tight busy-spin by sleeping before the next read attempt.
+            Thread.sleep(500);
           }
         }
       }


### PR DESCRIPTION
## What

`DevServerRunner.runBlocking()` calls `terminal.reader().read(100)` in a loop to wait for the user to press Enter. When stdin is a pipe, `/dev/null`, or any non-interactive stream (CI, `sbt run` backgrounded, Docker containers without a TTY), `read()` returns `-1` (EOF) immediately on every call. Because the loop has no guard for the EOF case, the thread spins at **100% CPU** for the entire lifetime of the dev server.

## How

Check the return value of `read()`: if it is `< 0` (EOF), sleep 500 ms before the next attempt. Enter (char 10) still breaks the loop immediately, and the 100 ms read timeout continues to provide low-latency response when a real terminal is attached. The dev server keeps running in both cases — only the busy-spin is eliminated.

## Testing

Reproducible with:
```sh
echo "" | ./gradlew liveReloadRun   # stdin is a pipe → CPU spikes to 100%
```
After the fix the thread sleeps between polls and CPU stays near zero while the server is idle.

Fixes #66

---
_I used an AI assistant for this change and verified the behaviour for both the interactive and non-interactive paths before submitting._