### PR TITLE
fix: close dependency classloader on shutdown

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
@@ -31,7 +31,7 @@ final class DevServerReloader implements BuildLink, Closeable {
 
   private final Supplier<Boolean> triggerReload;
 
-  private final ClassLoader dependenciesClassLoader;
+  private final URLClassLoader dependenciesClassLoader;
 
   // The current classloader for the application
   private volatile URLClassLoader currentApplicationClassLoader;
@@ -55,7 +55,7 @@ final class DevServerReloader implements BuildLink, Closeable {
   private final AtomicInteger classLoaderVersion = new AtomicInteger(0);
 
   DevServerReloader(
-      ClassLoader dependenciesClassLoader,
+      URLClassLoader dependenciesClassLoader,
       Supplier<CompileResult> compile,
       Supplier<Boolean> triggerReload,
       List<File> monitoredFiles,
@@ -214,15 +214,22 @@ final class DevServerReloader implements BuildLink, Closeable {
 
   @Override
   public void close() {
-    var cl = currentApplicationClassLoader;
+    // Release JAR handles held by the app loader and its dependency parent.
+    var appLoader = currentApplicationClassLoader;
     currentApplicationClassLoader = null;
-    if (cl != null) {
-      try {
-        cl.close();
-      } catch (IOException e) {
-        // best-effort cleanup on shutdown
-      }
-    }
+    closeQuietly(appLoader);
+    closeQuietly(dependenciesClassLoader);
     if (watcher != null) watcher.stop();
+  }
+
+  private static void closeQuietly(URLClassLoader loader) {
+    if (loader == null) {
+      return;
+    }
+    try {
+      loader.close();
+    } catch (IOException e) {
+      // best-effort cleanup on shutdown
+    }
   }
 }


### PR DESCRIPTION
## Summary

The dependency `URLClassLoader` built in `runBackground()` keeps an open file handle for every dependency JAR, but nothing ever closed it. Every liveReload start and stop cycle leaked one classloader together with all of those handles, so a long sbt or mill session can drift toward `Too many open files`, and on Windows the open JARs block the build from cleaning them.

The fix closes that loader inside `DevServerReloader.close()`, right after the application loader, so the whole classloader hierarchy is released on shutdown. Both closes now share one `closeQuietly` helper, and the field is typed as `URLClassLoader` so its closeability is guaranteed at compile time.

Fixes #79 

## How was it tested?

Covered by the existing sbt scripted and mill integration suites, which start the dev server, reload, and stop it, exercising the `DevServerReloader.close()` path that now also releases the dependency loader. No new behavior is added beyond freeing a handle that was previously leaked, so no framework specific test was introduced.

## Checklist

- [x] Ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] Ran `just code-format-check-all` and it passes
- [ ] Updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] Updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
