### PR TITLE
fix: set running state before the proxy listener accepts connections

### DIFF
--- a/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/BaseDevServerStart.java
@@ -95,6 +95,23 @@ public abstract class BaseDevServerStart<S> implements ReloadableServer {
   }
 
   /**
+   * Marks the server running and allocates the application thread group. Subclasses MUST call this
+   * before the proxy listener accepts connections: a request handled while {@link #isRunning} is
+   * still {@code false} hits the guard in {@link #startInternal}, surfaces as an {@link
+   * UnrecoverableException}, and gets escalated into a permanent {@code close()} of the dev server.
+   */
+  protected void markRunning() {
+    appThreadGroup = new ThreadGroup("app");
+    isRunning.set(true);
+  }
+
+  /** Reverts {@link #markRunning()} when startup fails afterwards. Safe to call if it never ran. */
+  protected void markStopped() {
+    isRunning.set(false);
+    appThreadGroup = null;
+  }
+
+  /**
    * Starts the underlying application server with the given generation.
    *
    * @param generation the reload generation containing the new class loader

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcDevServerStart.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcDevServerStart.java
@@ -64,14 +64,19 @@ public class GrpcDevServerStart extends BaseDevServerStart<Server> {
     ServerCredentials proxyCredentials = buildProxyServerCredentials();
     boolean proxyTls = !(proxyCredentials instanceof InsecureServerCredentials);
 
+    boolean started = false;
     try {
       var proxyAddress =
           new InetSocketAddress(settings.getProxyGrpcHost(), settings.getProxyGrpcPort());
       proxyServer =
           NettyServerBuilder.forAddress(proxyAddress, proxyCredentials)
               .fallbackHandlerRegistry(new GrpcProxyHandlerRegistry(logger, proxyHandler))
-              .build()
-              .start();
+              .build();
+
+      // Must run before the listener accepts connections; see markRunning().
+      markRunning();
+      proxyServer.start();
+      started = true;
 
       logger.info(
           "🚀 GRPC proxy server started on "
@@ -87,10 +92,11 @@ public class GrpcDevServerStart extends BaseDevServerStart<Server> {
     } catch (IOException e) {
       logger.error("Failed to start GRPC proxy server", e);
       throw new RuntimeException(e);
+    } finally {
+      if (!started) {
+        markStopped();
+      }
     }
-
-    appThreadGroup = new ThreadGroup("app");
-    isRunning.set(true);
   }
 
   @Override

--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/DevServerStart.java
@@ -42,10 +42,11 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
     }
 
     // Track resources we have already allocated so we can release them if a later
-    // step throws. Set to null after isRunning flips true; BaseDevServerStart.close()
+    // step throws. Set to null once startup succeeds; BaseDevServerStart.close()
     // takes over from there.
     XnioWorker workerToCleanup = null;
     Undertow proxyToCleanup = null;
+    boolean started = false;
     try {
       this.currentGenerationWorker = createWorker();
       workerToCleanup = this.currentGenerationWorker;
@@ -76,15 +77,19 @@ public class DevServerStart extends BaseDevServerStart<Undertow> {
               .setServerOption(UndertowOptions.SHUTDOWN_TIMEOUT, 1000)
               .build();
       proxyToCleanup = proxyServer;
+
+      // Must run before the listener accepts connections; see markRunning().
+      markRunning();
       proxyServer.start();
 
-      appThreadGroup = new ThreadGroup("app");
-
-      isRunning.set(true);
+      started = true;
       // Ownership transferred to the running server; do not clean up below.
       workerToCleanup = null;
       proxyToCleanup = null;
     } finally {
+      if (!started) {
+        markStopped();
+      }
       if (workerToCleanup != null) {
         // start() failed after the worker was created. Release its threads, and
         // null out the field so cleanupServerForOldGeneration() does not later try


### PR DESCRIPTION
## Summary

The proxy listener started accepting connections before the server marked itself as running. A request landing in that window reached `startInternal` while `isRunning` was still false, which surfaced as an `UnrecoverableException` and was escalated by the request handler into a full `close()` of the dev server, leaving it down until a manual restart. This moves the running state transition ahead of the listener so the window cannot exist.

Fixes #81 

The fix introduces a shared `markRunning` and `markStopped` pair on `BaseDevServerStart`. Both the HTTP proxy (`core/webserver`) and the GRPC proxy (`core/webserver-grpc`) now flip the running state and allocate the application thread group before their listener accepts connections, and revert it when startup fails. The GRPC path previously had no rollback on a failed start, so it gains one as well.

## How was it tested?

- The affected core modules compile cleanly.
- The failure is a startup ordering window rather than a deterministic case, so the change removes the window by construction instead of adding a timing dependent test. With the running state set before the listener accepts, an early request now flows through normal startup rather than the unrecoverable path.

## Checklist

- [x] Ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] Ran `just code-format-check-all` and it passes
- [ ] Updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] Updated the tested frameworks table if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
