### PR TITLE
fix: stop GRPC proxy capping messages at 4 MiB

### DIFF
--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcDevServerStart.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcDevServerStart.java
@@ -69,6 +69,7 @@ public class GrpcDevServerStart extends BaseDevServerStart<Server> {
           new InetSocketAddress(settings.getProxyGrpcHost(), settings.getProxyGrpcPort());
       proxyServer =
           NettyServerBuilder.forAddress(proxyAddress, proxyCredentials)
+              .maxInboundMessageSize(GrpcProxyDefaults.MAX_INBOUND_MESSAGE_SIZE)
               .fallbackHandlerRegistry(new GrpcProxyHandlerRegistry(logger, proxyHandler))
               .build()
               .start();

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcProxyDefaults.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/GrpcProxyDefaults.java
@@ -1,0 +1,18 @@
+package me.seroperson.reload.live.webserver.grpc;
+
+/** Shared defaults applied to every builder on the GRPC proxy data path. */
+final class GrpcProxyDefaults {
+
+  /**
+   * Inbound message-size cap applied to both the proxy listener and the upstream channel.
+   *
+   * <p>grpc-java defaults this to 4 MiB and enforces it at the deframing layer, before the
+   * pass-through marshaller ever runs. A transparent dev proxy must not impose a cap below what the
+   * real client and backend negotiated, so we lift it as high as the API allows ({@code int}
+   * bytes). Frame sizes are still bounded by the limits the actual endpoints enforce on their own
+   * connections.
+   */
+  static final int MAX_INBOUND_MESSAGE_SIZE = Integer.MAX_VALUE;
+
+  private GrpcProxyDefaults() {}
+}

--- a/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/ReloadableGrpcProxyHandler.java
+++ b/core/webserver-grpc/src/main/java/me/seroperson/reload/live/webserver/grpc/ReloadableGrpcProxyHandler.java
@@ -125,7 +125,9 @@ class ReloadableGrpcProxyHandler {
             + (useTls ? " (TLS)" : " (plaintext)"));
     ChannelCredentials credentials =
         useTls ? buildTlsCredentials() : InsecureChannelCredentials.create();
-    return Grpc.newChannelBuilderForAddress(targetHost, targetPort, credentials).build();
+    return Grpc.newChannelBuilderForAddress(targetHost, targetPort, credentials)
+        .maxInboundMessageSize(GrpcProxyDefaults.MAX_INBOUND_MESSAGE_SIZE)
+        .build();
   }
 
   private ChannelCredentials buildTlsCredentials() {


### PR DESCRIPTION
## Summary

The GRPC proxy relied on grpc-java's default 4 MiB `maxInboundMessageSize` on both the proxy listener and the upstream channel. That limit is enforced in the framing deframer before the pass-through marshaller runs, so any RPC larger than 4 MiB failed with `RESOURCE_EXHAUSTED` once the proxy was inserted, even though the same call worked against the backend directly. A transparent dev proxy should not impose its own cap, so the limit is lifted to `Integer.MAX_VALUE` on both builders and frame sizes stay bounded by whatever the real endpoints negotiate.

Fixes #83 

## How was it tested?

Manual verification: the changed `webserver-grpc` package was compiled against the real grpc-java jars to confirm both `maxInboundMessageSize` calls resolve and chain correctly on `NettyServerBuilder` and the `Grpc` channel builder.

A full end-to-end test belongs in the sbt GRPC scripted suite, but it needs the test client's own channel limit raised as well (the existing client builds its channel with the default 4 MiB inbound cap), so that follow-up is called out for a separate change.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
