### PR TITLE
fix: keep mill dev-server dependencies off the compile classpath

### DIFF
--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -27,8 +27,10 @@ trait LiveReloadModule extends JavaModule {
     HttpServerType
   }
 
-  override def mvnDeps =
-    super.mvnDeps() ++ {
+  // Runtime-only deps for the dev server: kept off the compile classpath and
+  // out of the published POM's compile scope, while staying in runClasspath.
+  override def runMvnDeps =
+    super.runMvnDeps() ++ {
       val webserverDep = liveServerType() match {
         case HttpServerType =>
           mvn"me.seroperson:jvm-live-reload-webserver:${BuildInfo.version}"


### PR DESCRIPTION
## Summary

The Mill `LiveReloadModule` added the dev-server artifacts (`jvm-live-reload-webserver` / `-grpc` and `jvm-live-reload-hook-scala`) through `mvnDeps`. In Mill that puts them on the compile classpath and writes them into the published POM as `compile`-scope dependencies, even though they are only needed at runtime by the in-process dev server and are loaded reflectively. Declaring them via `runMvnDeps` instead keeps them out of the compile classpath and publishes them as `runtime` scope, while they remain in `runClasspath` and `resolvedRunMvnDeps`, so the dev server and framework auto-detection behave exactly as before.

Fixes #85 

## How was it tested?

- Covered by the existing mill integration suite (`just test-mill`), which runs real builds through `liveReloadRun`; the deps still resolve via `resolvedRunMvnDeps`, so behavior is unchanged.
- Verified Mill 1.1.6 semantics directly on a minimal two-module build: with `mvnDeps` the artifact appears on `compileClasspath` and in the POM with `compile` scope; with `runMvnDeps` it is absent from `compileClasspath`, present in `resolvedRunMvnDeps`, and published with `runtime` scope.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
