### PR TITLE
fix: run reload off the proxy IO thread

### DIFF
--- a/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadHandler.java
+++ b/core/webserver/src/main/java/me/seroperson/reload/live/webserver/ReloadHandler.java
@@ -23,6 +23,13 @@ class ReloadHandler implements HttpHandler {
 
   @Override
   public void handleRequest(HttpServerExchange httpServerExchange) throws Exception {
+    // reload() blocks for seconds; move off the shared IO thread so other connections
+    // stay responsive during a reload.
+    if (httpServerExchange.isInIoThread()) {
+      httpServerExchange.dispatch(this);
+      return;
+    }
+
     try {
       var wasReloaded = server.reload();
 


### PR DESCRIPTION
## Summary

`ReloadHandler` is the Undertow root handler, so it runs on a shared XNIO IO thread, and it calls the blocking `server.reload()` that recompiles and restarts the application for several seconds. That freezes every other connection multiplexed on the same IO thread until the reload finishes. The handler now hands off to a worker thread before reloading, so the proxy stays responsive while a reload is in progress.

The fix is the canonical Undertow off IO thread handoff:

```java
if (httpServerExchange.isInIoThread()) {
  httpServerExchange.dispatch(this);
  return;
}
```

`ProxyHandler` already redispatches to the IO thread when it is entered from a worker thread, so the async proxy path is unaffected. A plain `dispatch(this)` is used on purpose instead of `BlockingHandler`, which would switch the exchange to stream IO and break the async response sender.

Fixes #87 

## How was it tested?

- Covered by the existing sbt scripted suite that exercises the reload flow (`just test-sbt`).
- Verified against Undertow 2.3.20 that `ProxyHandler.handleRequest` redispatches the proxy action to the IO thread when entered from a worker thread, so worker thread entry is safe.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [ ] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [ ] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
