### PR TITLE
feat: add Apache Pekko HTTP framework support

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,14 +476,19 @@ The complete list of built-in hooks:
     <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/zio/ZioZioAppShutdownHook.scala">ZioAppShutdownHook</a></td>
     <td>(<i>Scala-only</i>) Stops a <code>zio.ZIOApp</code>. Stops all internal executors if possible.</td>
   </tr>
+  <tr>
+    <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/pekko/PekkoHttpAppShutdownHook.scala">PekkoHttpAppShutdownHook</a></td>
+    <td>(<i>Scala-only</i>) Stops an Apache Pekko HTTP application. Interrupts the application thread and waits for the <code>ActorSystem</code> dispatcher threads to exit. Requires the application's <code>main</code> to call <code>system.terminate()</code> on <code>InterruptedException</code>.</td>
+  </tr>
 </table>
 
 The `sbt` and `mill` plugins also provide a set of predefined hooks, so-called
 hook bundles, which will be automatically used when a plugin finds the
 corresponding library in a classpath. Currently, supported sets are:
-`ZioAppHookBundle`, `IoAppHookBundle`, `CaskAppHookBundle` and
-`GrpcAppHookBundle` (picked automatically once `liveServerType` is set to
-`GrpcServerType`). All available options are defined in [HookBundle.scala][4].
+`ZioAppHookBundle`, `IoAppHookBundle`, `PekkoAppHookBundle`,
+`CaskAppHookBundle` and `GrpcAppHookBundle` (picked automatically once
+`liveServerType` is set to `GrpcServerType`). All available options are defined
+in [HookBundle.scala][4].
 You can also override a set of startup/shutdown hooks using the
 `liveStartupHooks` and `liveShutdownHooks` keys. For example:
 
@@ -580,6 +585,12 @@ whether their own setup will work.
     <td><i>http4s-ember-server</i> <b>0.23.30</b>, <i>cats-effect</i> <b>3.6.1</b>, <i>pureconfig</i> <b>0.17.9</b></td>
     <td>See <code>http4s-*</code> in <a href="https://github.com/seroperson/jvm-live-reload/tree/main/sbt/src/test/resources">sbt test resources</a> folder.</td>
     <td>Only <code>/health</code> endpoint.</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/apache/pekko-http">pekko-http</a> + <a href="https://github.com/apache/pekko">pekko</a></td>
+    <td><i>pekko-http</i> <b>1.1.0</b>, <i>pekko</i> <b>1.1.3</b></td>
+    <td>See <code>pekko-http</code> in <a href="https://github.com/seroperson/jvm-live-reload/tree/main/sbt/src/test/resources">sbt test resources</a> folder.</td>
+    <td><code>/health</code> endpoint, plus <code>main</code> must catch <code>InterruptedException</code> and call <code>system.terminate()</code>.</td>
   </tr>
   <tr>
     <td><a href="https://github.com/com-lihaoyi/cask">cask</a></td>

--- a/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/pekko/PekkoHttpAppShutdownHook.scala
+++ b/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/pekko/PekkoHttpAppShutdownHook.scala
@@ -1,0 +1,60 @@
+package me.seroperson.reload.live.hook.pekko
+
+import me.seroperson.reload.live.UnrecoverableException
+import me.seroperson.reload.live.build.BuildLogger
+import me.seroperson.reload.live.hook.Hook
+import me.seroperson.reload.live.reflect.MiscUtils
+import me.seroperson.reload.live.settings.DevServerSettings
+
+/** Shutdown hook for Apache Pekko HTTP applications.
+  *
+  * Interrupts the application thread and waits for the `ActorSystem` dispatcher
+  * threads to exit. The application `main` is expected to catch the
+  * `InterruptedException` and call `system.terminate()`; this hook only ensures
+  * no Pekko threads leak across a reload.
+  */
+class PekkoHttpAppShutdownHook extends Hook {
+
+  override def description: String =
+    "Shutdown an Apache Pekko HTTP application"
+
+  override def isAvailable: Boolean =
+    MiscUtils.hasClass("org.apache.pekko.actor.ActorSystem")
+
+  override def hook(
+      th: Thread,
+      cl: ClassLoader,
+      settings: DevServerSettings,
+      logger: BuildLogger
+  ): Unit = {
+    val timeoutMs: Long = settings.getThreadInterruptTimeoutMs()
+
+    def awaitExit(thread: Thread): Unit = {
+      thread.join(timeoutMs)
+      if (thread.isAlive) {
+        throw new UnrecoverableException(
+          s"Pekko thread '${thread.getName}' did not exit within ${timeoutMs}ms. " +
+            s"Make sure your main calls system.terminate() on InterruptedException, " +
+            s"or raise '${DevServerSettings.LiveReloadThreadInterruptTimeout}'."
+        )
+      }
+    }
+
+    th.interrupt()
+    logger.debug(s"Waiting up to ${timeoutMs}ms for Pekko threads to finish")
+    awaitExit(th)
+
+    // The app thread only returns once terminate() completes, so any remaining
+    // dispatcher threads should already be winding down; join them to be sure.
+    val appThreadGroup = th.getThreadGroup
+    if (appThreadGroup != null) {
+      val threads = new Array[Thread](appThreadGroup.activeCount())
+      val count = appThreadGroup.enumerate(threads)
+      threads
+        .take(count)
+        .filter(t => t != null && t.getName.contains("pekko.actor"))
+        .foreach(awaitExit)
+    }
+  }
+
+}

--- a/mill/src/HookBundle.scala
+++ b/mill/src/HookBundle.scala
@@ -29,6 +29,17 @@ case object IoAppHookBundle extends HookBundle {
   )
 }
 
+case object PekkoAppHookBundle extends HookBundle {
+  def startupHooks: Seq[String] = Seq(
+    HookClassnames.RestApiHealthCheckStartup
+  )
+  def shutdownHooks: Seq[String] = Seq(
+    HookClassnames.PekkoHttpAppShutdown,
+    HookClassnames.RuntimeShutdown,
+    HookClassnames.RestApiHealthCheckShutdown
+  )
+}
+
 case object CaskAppHookBundle extends HookBundle {
   def startupHooks: Seq[String] = Seq(
     HookClassnames.RestApiHealthCheckStartup

--- a/mill/src/HookClassnames.scala
+++ b/mill/src/HookClassnames.scala
@@ -9,6 +9,7 @@ object HookClassnames {
 
   val IoAppShutdown = "me.seroperson.reload.live.hook.io.IoAppShutdownHook"
   val ZioAppShutdown = "me.seroperson.reload.live.hook.zio.ZioAppShutdownHook"
+  val PekkoHttpAppShutdown = "me.seroperson.reload.live.hook.pekko.PekkoHttpAppShutdownHook"
   val RuntimeShutdown = "me.seroperson.reload.live.hook.RuntimeShutdownHook"
   val RestApiHealthCheckShutdown = "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook"
   val GrpcHealthCheckShutdown = "me.seroperson.reload.live.webserver.grpc.hook.GrpcHealthCheckShutdownHook"

--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -84,6 +84,7 @@ trait LiveReloadModule extends JavaModule {
       def has(prefix: String): Boolean = jarNames.exists(_.startsWith(prefix))
       if (has("zio-http")) Some(ZioAppHookBundle)
       else if (has("http4s")) Some(IoAppHookBundle)
+      else if (has("pekko-http")) Some(PekkoAppHookBundle)
       else if (has("cask")) Some(CaskAppHookBundle)
       else if (has("zio")) Some(ZioAppHookBundle)
       else if (has("cats-effect")) Some(IoAppHookBundle)

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/HookBundle.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/HookBundle.scala
@@ -29,6 +29,17 @@ case object IoAppHookBundle extends HookBundle {
   )
 }
 
+case object PekkoAppHookBundle extends HookBundle {
+  def startupHooks: Seq[String] = Seq(
+    LiveKeys.HookClassnames.RestApiHealthCheckStartup
+  )
+  def shutdownHooks: Seq[String] = Seq(
+    LiveKeys.HookClassnames.PekkoHttpAppShutdown,
+    LiveKeys.HookClassnames.RuntimeShutdown,
+    LiveKeys.HookClassnames.RestApiHealthCheckShutdown
+  )
+}
+
 case object CaskAppHookBundle extends HookBundle {
   def startupHooks: Seq[String] = Seq(
     LiveKeys.HookClassnames.RestApiHealthCheckStartup

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
@@ -25,6 +25,7 @@ object LiveKeys {
 
     val IoAppShutdown = "me.seroperson.reload.live.hook.io.IoAppShutdownHook"
     val ZioAppShutdown = "me.seroperson.reload.live.hook.zio.ZioAppShutdownHook"
+    val PekkoHttpAppShutdown = "me.seroperson.reload.live.hook.pekko.PekkoHttpAppShutdownHook"
     val RuntimeShutdown = "me.seroperson.reload.live.hook.RuntimeShutdownHook"
     val RestApiHealthCheckShutdown = "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook"
     val GrpcHealthCheckShutdown = "me.seroperson.reload.live.webserver.grpc.hook.GrpcHealthCheckShutdownHook"

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveReloadPlugin.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveReloadPlugin.scala
@@ -74,6 +74,8 @@ object LiveReloadPlugin extends AutoPlugin {
               ZioAppHookBundle
             case lib if SbtCompat.fileName(lib.data).startsWith("http4s") =>
               IoAppHookBundle
+            case lib if SbtCompat.fileName(lib.data).startsWith("pekko-http") =>
+              PekkoAppHookBundle
             case lib if SbtCompat.fileName(lib.data).startsWith("cask") =>
               CaskAppHookBundle
           }

--- a/sbt/src/test/resources/pekko-http/build.sbt
+++ b/sbt/src/test/resources/pekko-http/build.sbt
@@ -1,0 +1,34 @@
+val PekkoHttpVersion = "1.1.0"
+val PekkoVersion = "1.1.3"
+
+enablePlugins(LiveReloadPlugin)
+enablePlugins(BuildInfoPlugin)
+
+scalaVersion := "2.13.16"
+resolvers += Resolver.mavenLocal
+libraryDependencies ++= Seq(
+  "org.apache.pekko" %% "pekko-http" % PekkoHttpVersion,
+  "org.apache.pekko" %% "pekko-actor" % PekkoVersion,
+  "org.apache.pekko" %% "pekko-stream" % PekkoVersion
+)
+
+val isSbt2 = settingKey[Boolean]("isSbt2")
+isSbt2 := (sbtBinaryVersion.value match {
+  case "2" => true
+  case _   => false
+})
+
+val proxyPort = settingKey[Int]("proxyPort")
+proxyPort := sys.props.get("testkit.proxyPort").map(_.toInt).getOrElse(if (isSbt2.value) 9001 else 9000)
+
+val port = settingKey[Int]("port")
+port := sys.props.get("testkit.port").map(_.toInt).getOrElse(if (isSbt2.value) 8081 else 8080)
+
+liveDevSettings := Seq(
+  DevSettingsKeys.LiveReloadProxyHttpPort -> proxyPort.value.toString,
+  DevSettingsKeys.LiveReloadHttpPort -> port.value.toString,
+  DevSettingsKeys.LiveReloadIsDebug -> "true"
+)
+
+buildInfoKeys := Seq[BuildInfoKey](port)
+buildInfoPackage := "me.seroperson"

--- a/sbt/src/test/resources/pekko-http/changes/App.scala.1
+++ b/sbt/src/test/resources/pekko-http/changes/App.scala.1
@@ -1,0 +1,41 @@
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.server.Directives._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object App {
+
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("pekko-http-app")
+    import system.dispatcher
+
+    val route =
+      concat(
+        path("greet_reloaded") {
+          get {
+            complete("World Hello")
+          }
+        },
+        path("health") {
+          get {
+            complete(StatusCodes.OK)
+          }
+        }
+      )
+
+    val binding = Await.result(
+      Http().newServerAt("0.0.0.0", me.seroperson.BuildInfo.port).bind(route),
+      30.seconds
+    )
+
+    try {
+      Await.result(system.whenTerminated, Duration.Inf)
+    } catch {
+      case _: InterruptedException =>
+        Await.result(binding.unbind(), 30.seconds)
+        Await.result(system.terminate(), 30.seconds)
+    }
+  }
+}

--- a/sbt/src/test/resources/pekko-http/project/plugins.sbt
+++ b/sbt/src/test/resources/pekko-http/project/plugins.sbt
@@ -1,0 +1,6 @@
+updateOptions := updateOptions.value.withLatestSnapshots(false)
+
+resolvers += Resolver.mavenLocal
+
+addSbtPlugin("me.seroperson" % "sbt-live-reload" % sys.props("project.version"))
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")

--- a/sbt/src/test/resources/pekko-http/src/main/scala/App.scala
+++ b/sbt/src/test/resources/pekko-http/src/main/scala/App.scala
@@ -1,0 +1,43 @@
+import org.apache.pekko.actor.ActorSystem
+import org.apache.pekko.http.scaladsl.Http
+import org.apache.pekko.http.scaladsl.model.StatusCodes
+import org.apache.pekko.http.scaladsl.server.Directives._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+object App {
+
+  def main(args: Array[String]): Unit = {
+    implicit val system: ActorSystem = ActorSystem("pekko-http-app")
+    import system.dispatcher
+
+    val route =
+      concat(
+        path("greet") {
+          get {
+            complete("Hello World")
+          }
+        },
+        path("health") {
+          get {
+            complete(StatusCodes.OK)
+          }
+        }
+      )
+
+    val binding = Await.result(
+      Http().newServerAt("0.0.0.0", me.seroperson.BuildInfo.port).bind(route),
+      30.seconds
+    )
+
+    // Block the main thread until live-reload interrupts it, then gracefully
+    // terminate the ActorSystem so its dispatcher threads exit before reload.
+    try {
+      Await.result(system.whenTerminated, Duration.Inf)
+    } catch {
+      case _: InterruptedException =>
+        Await.result(binding.unbind(), 30.seconds)
+        Await.result(system.terminate(), 30.seconds)
+    }
+  }
+}

--- a/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
+++ b/sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala
@@ -38,6 +38,16 @@ class LiveReloadSpec extends LiveReloadBase {
     }
   }
 
+  testEach("pekko-http - live reload on source change") { sbtVersion =>
+    withRunner("pekko-http", sbtVersion) { (runner, proxyPort) =>
+      runner.run("bgRun")
+      verifyHttp("greet", 200, Some("Hello World"), proxyPort)
+      runner.copyFile("changes/App.scala.1", "src/main/scala/App.scala")
+      verifyHttp("greet_reloaded", 200, Some("World Hello"), proxyPort)
+      verifyHttp("greet", 404, port = proxyPort)
+    }
+  }
+
   testEach("cask - live reload on source change") { sbtVersion =>
     withRunner("cask", sbtVersion) { (runner, proxyPort) =>
       runner.run("bgRun")


### PR DESCRIPTION
## Summary

Adds Apache Pekko HTTP to the supported frameworks. Pekko HTTP runs a long running `ActorSystem` whose dispatcher threads survive a plain `Thread.interrupt()`, the same shape already covered for zio and cats-effect, so it needs a dedicated shutdown hook to avoid leaking threads across reloads.

What it adds:

* `core/hook-scala`: `PekkoHttpAppShutdownHook`, available when `org.apache.pekko.actor.ActorSystem` is present. It interrupts the app thread, then waits for the `ActorSystem` dispatcher threads to exit, throwing `UnrecoverableException` on timeout.
* sbt and mill plugins: `PekkoAppHookBundle` plus `pekko-http` jar name detection, following the existing `zio-http` and `http4s` branches. The bundle pairs the standard health check startup with the Pekko shutdown, mirroring `CaskAppHookBundle`.
* A scripted fixture under `sbt/src/test/resources/pekko-http/` with a minimal interruptible server that terminates the `ActorSystem` on `InterruptedException`, plus a reload variant.
* `README.md`: a row in the tested frameworks table and an entry in the hooks table.

The application main stays responsible for calling `system.terminate()` on `InterruptedException`, consistent with the documented interruptible main contract, so no reflection into the running `ActorSystem` is needed.

Closes #89 

## How was it tested?

New scripted test `pekko-http - live reload on source change` in `sbt/src/test/scala/me/seroperson/reload/live/LiveReloadSpec.scala`, run against both sbt `1.12.3` and `2.0.0-RC10`:

```sh
export JDK_JAVA_OPTIONS="--add-opens=java.base/java.util=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED"
sbt 'testOnly *LiveReloadSpec -- -z pekko-http'
# Tests: succeeded 2, failed 0
```

The run confirms the reload serves updated code, the `/health` gate works, and no dispatcher threads leak across reloads. The scalafmt formatting check passes as well.

## Checklist

- [x] Relevant test recipe ran locally (`pekko-http` scripted test on sbt `1.12.3` and `2.0.0-RC10`)
- [x] Scala formatting check passes (`scalafmt`); the change touches no Gradle or Kotlin sources
- [x] Updated `README.md` for the new hook, hook bundle and supported framework
- [x] Updated the tested frameworks table
- [x] No unrelated files were reformatted or refactored
