### PR TITLE
feat: add Spring Boot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -529,6 +529,47 @@ object app extends LiveReloadModule, ScalaModule {
 }
 ```
 
+### Spring Boot
+
+Spring Boot needs special handling. A typical `main()` just calls
+`SpringApplication.run(...)` and returns, while the embedded Tomcat/Netty server
+keeps running on its own non-daemon threads. The generic
+`ThreadInterruptShutdownHook` can't stop it (the main thread has already
+finished), so on reload the embedded server would leak threads and hold the
+port. Instead, a dedicated `SpringBootAppShutdownHook` closes the running
+`ApplicationContext` (which stops the embedded server and joins its threads)
+before the next generation starts.
+
+For `sbt` and `mill` this is wired automatically — the `spring-boot` dependency
+is detected and the Spring Boot hook bundle is applied. For `gradle` (which has
+no auto-detection) set the hooks explicitly:
+
+```kotlin
+liveReload {
+  // The startup hook stays at its default value
+  shutdownHooks = listOf(
+    "me.seroperson.reload.live.hook.spring.SpringBootAppShutdownHook",
+    "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook",
+  )
+}
+```
+
+Notes:
+
+- Do **not** add `RuntimeShutdownHook` to a Spring Boot setup. It runs Spring's
+  static `SpringApplicationShutdownHook` (a JVM shutdown hook), which permanently
+  marks shutdown as in-progress and breaks the next generation's
+  `SpringApplication.run(...)`. `SpringBootAppShutdownHook` closes the context
+  gracefully on its own.
+
+- Expose a `/health` endpoint (any `2xx`), same as every other framework.
+- **Remove `spring-boot-devtools`.** DevTools ships its own restart classloader,
+  which conflicts with the reloading performed by this plugin. It must be absent
+  (or disabled) when using `jvm-live-reload`.
+- On reload the `ApplicationContext` is closed and the embedded Tomcat/Netty
+  threads are joined within `live.reload.thread-interrupt-timeout` (default
+  `15000` ms). If shutdown is slow, increase that timeout.
+
 ### Propagate environment
 
 This plugin provides a feature to propagate custom environment variables to a
@@ -610,6 +651,12 @@ whether their own setup will work.
     <td><i>grpc-java</i> <b>1.72.0</b></td>
     <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcTest.kt">LiveReloadGrpcTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcStreamingTest.kt">LiveReloadGrpcStreamingTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcReflectionTest.kt">LiveReloadGrpcReflectionTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcTlsTest.kt">LiveReloadGrpcTlsTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcMultiprojectTest.kt">LiveReloadGrpcMultiprojectTest.kt</a></td>
     <td>Expose <code>grpc.health.v1.Health</code> plus everything from <a href="#changes-to-the-application-code">this section</a>.</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/spring-projects/spring-boot">spring-boot</a> (Spring MVC / WebFlux)</td>
+    <td><i>spring-boot</i> <b>3.3.5</b></td>
+    <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSpringBootTest.kt">LiveReloadSpringBootTest.kt</a></td>
+    <td>Expose <code>/health</code>, remove <code>spring-boot-devtools</code>, and (for <code>gradle</code>) set the Spring Boot <code>shutdownHooks</code> — see <a href="#spring-boot">below</a>. <code>sbt</code> / <code>mill</code> auto-detect <code>spring-boot</code>.</td>
   </tr>
   <tr>
     <td><a href="https://github.com/scalapb/ScalaPB">scalapb</a> + <a href="https://github.com/grpc/grpc-java">grpc-netty</a></td>

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/spring/SpringBootAppShutdownHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/spring/SpringBootAppShutdownHook.java
@@ -1,0 +1,117 @@
+package me.seroperson.reload.live.hook.spring;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import me.seroperson.reload.live.build.BuildLogger;
+import me.seroperson.reload.live.hook.Hook;
+import me.seroperson.reload.live.reflect.MiscUtils;
+import me.seroperson.reload.live.settings.DevServerSettings;
+
+/**
+ * Closes the running Spring Boot {@code ApplicationContext}(s) on reload.
+ *
+ * <p>A Spring Boot {@code main()} returns immediately while the embedded server keeps running on its
+ * own non-daemon threads, so interrupting the main thread can't stop it. This hook discovers the
+ * live contexts through Spring's static {@code SpringApplicationShutdownHook} and closes them, which
+ * stops the embedded server and joins its threads. All reflection targets the reloaded classloader,
+ * where Spring lives.
+ */
+public class SpringBootAppShutdownHook implements Hook {
+
+  @Override
+  public String description() {
+    return "Closes running Spring Boot ApplicationContext(s)";
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return MiscUtils.hasClass("org.springframework.boot.SpringApplication");
+  }
+
+  @Override
+  public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    List<Object> contexts;
+    try {
+      contexts = runningContexts(cl);
+    } catch (ReflectiveOperationException | RuntimeException ex) {
+      logger.warn("Unable to locate Spring Boot ApplicationContext(s): " + ex.getMessage());
+      return;
+    }
+
+    if (contexts.isEmpty()) {
+      logger.debug("No running Spring Boot ApplicationContext found");
+      return;
+    }
+
+    for (Object ctx : contexts) {
+      try {
+        logger.debug("Closing Spring Boot ApplicationContext " + ctx);
+        ctx.getClass().getMethod("close").invoke(ctx);
+      } catch (ReflectiveOperationException ex) {
+        logger.error("Failed to close Spring Boot ApplicationContext " + ctx, ex);
+      }
+    }
+
+    awaitThreadShutdown(th, settings.getThreadInterruptTimeoutMs(), logger);
+  }
+
+  /** Snapshot of the contexts tracked by Spring's static shutdown hook. */
+  private List<Object> runningContexts(ClassLoader cl) throws ReflectiveOperationException {
+    Class<?> springApplication =
+        Class.forName("org.springframework.boot.SpringApplication", false, cl);
+
+    Field hookField = springApplication.getDeclaredField("shutdownHook");
+    hookField.setAccessible(true);
+    Object shutdownHook = hookField.get(null);
+    if (shutdownHook == null) {
+      return List.of();
+    }
+
+    Field contextsField = shutdownHook.getClass().getDeclaredField("contexts");
+    contextsField.setAccessible(true);
+    if (!(contextsField.get(shutdownHook) instanceof Set<?> contexts)) {
+      return List.of();
+    }
+    // Copy: closing a context removes it from the live set.
+    return new ArrayList<>(contexts);
+  }
+
+  /** Bounded wait for the embedded server's non-daemon threads to finish; warns on leftovers. */
+  private void awaitThreadShutdown(Thread th, long timeoutMs, BuildLogger logger) {
+    ThreadGroup group = th.getThreadGroup();
+    if (group == null) {
+      return;
+    }
+
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    Thread[] threads = new Thread[group.activeCount() + 8];
+    int count = group.enumerate(threads);
+
+    List<Thread> leaked = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      Thread t = threads[i];
+      if (t == Thread.currentThread() || t.isDaemon()) {
+        continue;
+      }
+      long remaining = deadline - System.currentTimeMillis();
+      if (remaining > 0) {
+        try {
+          t.join(remaining);
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+      }
+      if (t.isAlive()) {
+        leaked.add(t);
+      }
+    }
+
+    if (!leaked.isEmpty()) {
+      logger.warn("Spring Boot shutdown left non-daemon threads alive after " + timeoutMs + "ms: "
+          + leaked);
+    }
+  }
+}

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSpringBootTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSpringBootTest.kt
@@ -1,0 +1,144 @@
+package me.seroperson.reload.live.gradle
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class LiveReloadSpringBootTest : LiveReloadTestBase() {
+    @field:TempDir lateinit var projectDir: File
+
+    private val appCode by lazy {
+        val kotlinSources = projectDir.resolve("src/main/kotlin/app")
+        kotlinSources.mkdirs()
+        kotlinSources.resolve("App.kt")
+    }
+    private val appProperties by lazy {
+        val resources = projectDir.resolve("src/main/resources")
+        resources.mkdirs()
+        resources.resolve("application.properties")
+    }
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+
+    @Test
+    fun `reload spring boot`() {
+        settingsFile.writeText(SETTINGS_CONTENT)
+        buildFile.writeText(BUILD_CONTENT)
+        appProperties.writeText(APP_PROPERTIES)
+        appCode.writeText(APP_CODE_1)
+
+        val runner = initGradleRunner(":liveReloadRun", projectDir)
+        val isBuildRunning = AtomicBoolean(true)
+        val runThread =
+            Thread {
+                try {
+                    runner.build()
+                    isBuildRunning.set(false)
+                } catch (_: InterruptedException) {
+                    println("Interrupted")
+                } catch (ex: Exception) {
+                    println("Got exception ${ex.message}")
+                }
+            }
+        runThread.start()
+
+        val greet = runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "Hello World")
+
+        appCode.writeText(APP_CODE_2)
+
+        val greetReloaded =
+            runUntil(isBuildRunning, "http://localhost:9000/greet_reloaded", 200, "World Hello")
+
+        runThread.interrupt()
+
+        assertTrue(greet && greetReloaded)
+    }
+
+    companion object {
+        const val SETTINGS_CONTENT = ""
+        const val APP_PROPERTIES =
+            """
+server.port=8081
+spring.main.banner-mode=off
+"""
+        const val BUILD_CONTENT =
+            """
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    id("org.jetbrains.kotlin.plugin.spring") version "2.2.0"
+    application
+    id("me.seroperson.reload.live.gradle")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("org.springframework.boot:spring-boot-starter-web:3.3.5")
+}
+
+liveReload {
+    settings = mapOf("live.reload.http.port" to "8081")
+    shutdownHooks = listOf(
+        "me.seroperson.reload.live.hook.spring.SpringBootAppShutdownHook",
+        "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook",
+    )
+}
+
+application { mainClass = "app.AppKt" }
+"""
+        const val APP_CODE_1 =
+            """
+package app
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@SpringBootApplication
+@RestController
+class App {
+    @GetMapping("/greet")
+    fun greet(): String = "Hello World"
+
+    @GetMapping("/health")
+    fun health(): String = "OK"
+}
+
+fun main(args: Array<String>) {
+    runApplication<App>(*args)
+}
+"""
+        const val APP_CODE_2 =
+            """
+package app
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@SpringBootApplication
+@RestController
+class App {
+    @GetMapping("/greet_reloaded")
+    fun greetReloaded(): String = "World Hello"
+
+    @GetMapping("/health")
+    fun health(): String = "OK"
+}
+
+fun main(args: Array<String>) {
+    runApplication<App>(*args)
+}
+"""
+    }
+}

--- a/mill/src/HookBundle.scala
+++ b/mill/src/HookBundle.scala
@@ -40,6 +40,18 @@ case object CaskAppHookBundle extends HookBundle {
   )
 }
 
+case object SpringBootAppHookBundle extends HookBundle {
+  def startupHooks: Seq[String] = Seq(
+    HookClassnames.RestApiHealthCheckStartup
+  )
+  // No RuntimeShutdownHook: running Spring's JVM shutdown hook flips its `inProgress`
+  // flag for good and breaks the next SpringApplication.run().
+  def shutdownHooks: Seq[String] = Seq(
+    HookClassnames.SpringBootAppShutdown,
+    HookClassnames.RestApiHealthCheckShutdown
+  )
+}
+
 case object GrpcAppHookBundle extends HookBundle {
   def startupHooks: Seq[String] = Seq(
     HookClassnames.GrpcHealthCheckStartup

--- a/mill/src/HookClassnames.scala
+++ b/mill/src/HookClassnames.scala
@@ -9,6 +9,7 @@ object HookClassnames {
 
   val IoAppShutdown = "me.seroperson.reload.live.hook.io.IoAppShutdownHook"
   val ZioAppShutdown = "me.seroperson.reload.live.hook.zio.ZioAppShutdownHook"
+  val SpringBootAppShutdown = "me.seroperson.reload.live.hook.spring.SpringBootAppShutdownHook"
   val RuntimeShutdown = "me.seroperson.reload.live.hook.RuntimeShutdownHook"
   val RestApiHealthCheckShutdown = "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook"
   val GrpcHealthCheckShutdown = "me.seroperson.reload.live.webserver.grpc.hook.GrpcHealthCheckShutdownHook"

--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -85,6 +85,7 @@ trait LiveReloadModule extends JavaModule {
       if (has("zio-http")) Some(ZioAppHookBundle)
       else if (has("http4s")) Some(IoAppHookBundle)
       else if (has("cask")) Some(CaskAppHookBundle)
+      else if (has("spring-boot")) Some(SpringBootAppHookBundle)
       else if (has("zio")) Some(ZioAppHookBundle)
       else if (has("cats-effect")) Some(IoAppHookBundle)
       else None

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/HookBundle.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/HookBundle.scala
@@ -40,6 +40,18 @@ case object CaskAppHookBundle extends HookBundle {
   )
 }
 
+case object SpringBootAppHookBundle extends HookBundle {
+  def startupHooks: Seq[String] = Seq(
+    LiveKeys.HookClassnames.RestApiHealthCheckStartup
+  )
+  // No RuntimeShutdownHook: running Spring's JVM shutdown hook flips its `inProgress`
+  // flag for good and breaks the next SpringApplication.run().
+  def shutdownHooks: Seq[String] = Seq(
+    LiveKeys.HookClassnames.SpringBootAppShutdown,
+    LiveKeys.HookClassnames.RestApiHealthCheckShutdown
+  )
+}
+
 case object GrpcAppHookBundle extends HookBundle {
   def startupHooks: Seq[String] = Seq(
     LiveKeys.HookClassnames.GrpcHealthCheckStartup

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
@@ -25,6 +25,7 @@ object LiveKeys {
 
     val IoAppShutdown = "me.seroperson.reload.live.hook.io.IoAppShutdownHook"
     val ZioAppShutdown = "me.seroperson.reload.live.hook.zio.ZioAppShutdownHook"
+    val SpringBootAppShutdown = "me.seroperson.reload.live.hook.spring.SpringBootAppShutdownHook"
     val RuntimeShutdown = "me.seroperson.reload.live.hook.RuntimeShutdownHook"
     val RestApiHealthCheckShutdown = "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook"
     val GrpcHealthCheckShutdown = "me.seroperson.reload.live.webserver.grpc.hook.GrpcHealthCheckShutdownHook"

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveReloadPlugin.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveReloadPlugin.scala
@@ -76,6 +76,9 @@ object LiveReloadPlugin extends AutoPlugin {
               IoAppHookBundle
             case lib if SbtCompat.fileName(lib.data).startsWith("cask") =>
               CaskAppHookBundle
+            case lib
+                if SbtCompat.fileName(lib.data).startsWith("spring-boot") =>
+              SpringBootAppHookBundle
           }
       }
     ),


### PR DESCRIPTION
## Summary

Adds Spring Boot (Spring MVC and WebFlux) to the list of supported frameworks. A Spring Boot `main()` returns as soon as `SpringApplication.run(...)` hands back the context, while the embedded server keeps running on its own non-daemon threads, so a reload used to leave the old server holding the port and leaking threads. A new `SpringBootAppShutdownHook` closes the running `ApplicationContext` on reload, which stops the embedded server and joins its threads, and the sbt and mill plugins now detect `spring-boot` automatically.

Closes #91 

## How was it tested?

New functional test: `gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSpringBootTest.kt`. It boots a Spring Boot app behind the proxy, confirms `/greet` is served once `/health` is ready, edits the controller, and confirms `/greet_reloaded` is served after a clean reload with no port conflict and no thread leak. Verified locally with `just test-gradle`.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [x] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
