### PR TITLE
feat: add Micronaut support

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,10 @@ The complete list of built-in hooks:
     <td>Calls <code>Thread.interrupt()</code> on the main thread.</td>
   </tr>
   <tr>
+    <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/core/build-link/src/main/java/me/seroperson/reload/live/hook/MicronautAppShutdownHook.java">MicronautAppShutdownHook</a></td>
+    <td>Stops a Micronaut <code>ApplicationContext</code> (the embedded Netty server) and waits for its server threads to terminate. Needed because <code>Micronaut.run(...)</code> returns immediately, leaving no main thread to interrupt.</td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/core/hook-scala/src/main/scala/me/seroperson/reload/live/hook/io/IoAppStartupHook.scala">IoAppStartupHook</a></td>
     <td>(<i>Scala-only</i>) Starts a <code>cats.effect.IOApp</code>. Basically, it just sets an internal property to strip unnecessary logging.</td>
   </tr>
@@ -481,9 +485,11 @@ The complete list of built-in hooks:
 The `sbt` and `mill` plugins also provide a set of predefined hooks, so-called
 hook bundles, which will be automatically used when a plugin finds the
 corresponding library in a classpath. Currently, supported sets are:
-`ZioAppHookBundle`, `IoAppHookBundle`, `CaskAppHookBundle` and
-`GrpcAppHookBundle` (picked automatically once `liveServerType` is set to
-`GrpcServerType`). All available options are defined in [HookBundle.scala][4].
+`ZioAppHookBundle`, `IoAppHookBundle`, `CaskAppHookBundle`,
+`MicronautAppHookBundle` (picked automatically once `micronaut` is found on the
+classpath) and `GrpcAppHookBundle` (picked automatically once `liveServerType`
+is set to `GrpcServerType`). All available options are defined in
+[HookBundle.scala][4].
 You can also override a set of startup/shutdown hooks using the
 `liveStartupHooks` and `liveShutdownHooks` keys. For example:
 
@@ -526,6 +532,40 @@ object app extends LiveReloadModule, ScalaModule {
       HookClassnames.RestApiHealthCheckStartup
     )
   }
+}
+```
+
+The `gradle` plugin does not auto-detect frameworks, so a Micronaut application
+needs the Micronaut shutdown hook wired explicitly. A typical
+`Micronaut.run(...)` entry point starts the embedded server on its own threads
+and returns immediately, so `MicronautAppShutdownHook` is used instead of
+`ThreadInterruptShutdownHook`:
+
+```kotlin
+liveReload {
+  settings = mapOf("live.reload.http.port" to "8081")
+  shutdownHooks = listOf(
+    "me.seroperson.reload.live.hook.MicronautAppShutdownHook",
+    "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook",
+  )
+}
+```
+
+The same hook works for `sbt` and `mill`, where `MicronautAppHookBundle` selects
+it automatically once `micronaut` is on the classpath.
+
+Besides exposing a `/health` endpoint, a Micronaut application has to be started
+so that Micronaut scans the reloaded class loader for beans (otherwise the
+reloaded controllers are invisible and every route returns `404`). Pass the
+application's class loader explicitly instead of using the bare
+`Micronaut.run(...)`:
+
+```java
+public static void main(String[] args) {
+    Micronaut.build(args)
+        .classLoader(Application.class.getClassLoader())
+        .mainClass(Application.class)
+        .start();
 }
 ```
 
@@ -604,6 +644,12 @@ whether their own setup will work.
     <td><i>javalin</i> <b>6.7.0</b>, <i>jte</i> <b>3.2.2</b></td>
     <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/plugin/plugin/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadJavalinTest.kt">LiveReloadJavalinTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/plugin/plugin/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadJavalinJteTest.kt">LiveReloadJavalinJteTest.kt</a></td>
     <td>Everything from <a href="#changes-to-the-application-code">this section</a>.</td>
+  </tr>
+  <tr>
+    <td><a href="https://github.com/micronaut-projects/micronaut-core">micronaut</a> (Java, Netty embedded server)</td>
+    <td><i>micronaut</i> <b>4.7.6</b></td>
+    <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadMicronautTest.kt">LiveReloadMicronautTest.kt</a></td>
+    <td>Expose a <code>/health</code> endpoint and start via <code>Micronaut.build(args).classLoader(Application.class.getClassLoader()).mainClass(Application.class).start()</code> so Micronaut scans the reloaded class loader for beans.</td>
   </tr>
   <tr>
     <td><a href="https://github.com/grpc/grpc-java">grpc-java</a> (Kotlin, unary + streaming + reflection + TLS)</td>

--- a/core/build-link/src/main/java/me/seroperson/reload/live/hook/MicronautAppShutdownHook.java
+++ b/core/build-link/src/main/java/me/seroperson/reload/live/hook/MicronautAppShutdownHook.java
@@ -1,0 +1,103 @@
+package me.seroperson.reload.live.hook;
+
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
+import java.util.List;
+import me.seroperson.reload.live.UnrecoverableException;
+import me.seroperson.reload.live.build.BuildLogger;
+import me.seroperson.reload.live.reflect.MiscUtils;
+import me.seroperson.reload.live.reflect.ShutdownHook;
+import me.seroperson.reload.live.settings.DevServerSettings;
+
+/**
+ * Shutdown hook for Micronaut applications.
+ *
+ * <p>{@code Micronaut.run(...)} starts the embedded (Netty) server on its own threads and returns,
+ * so the application {@code main} thread is already gone by shutdown time and {@link
+ * ThreadInterruptShutdownHook} has nothing to interrupt. Instead, this hook triggers the JVM
+ * shutdown hook Micronaut registers to close the {@code ApplicationContext} (i.e. {@code
+ * context.stop()}), then waits for the server threads of the current reload generation to finish so
+ * none leak across reloads.
+ *
+ * <p>Those threads are matched by their context {@link ClassLoader}: the runner starts the
+ * application under the reloaded class loader and Netty's threads inherit it, which also avoids
+ * touching the dev-server's own proxy threads.
+ */
+public class MicronautAppShutdownHook implements Hook {
+
+  @Override
+  public String description() {
+    return "Stops a Micronaut ApplicationContext and joins its server threads";
+  }
+
+  @Override
+  public boolean isAvailable() {
+    return MiscUtils.hasClass("io.micronaut.context.ApplicationContext");
+  }
+
+  @Override
+  public void hook(Thread th, ClassLoader cl, DevServerSettings settings, BuildLogger logger) {
+    // Run Micronaut's JVM shutdown hook to stop the context, then reset the hooks so the next
+    // reload generation starts clean.
+    ShutdownHook.runApplicationShutdownHooks(logger);
+    ShutdownHook.setShutdownHooks(new IdentityHashMap<>());
+
+    long timeoutMs = settings.getThreadInterruptTimeoutMs();
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    logger.debug("Waiting up to " + timeoutMs + "ms for Micronaut server threads to finish");
+
+    List<Thread> serverThreads = applicationThreads(cl);
+    for (Thread t : serverThreads) {
+      long remaining = deadline - System.currentTimeMillis();
+      if (remaining <= 0) {
+        break;
+      }
+      try {
+        t.join(remaining);
+      } catch (InterruptedException ex) {
+        Thread.currentThread().interrupt();
+        logger.error("Interrupted while waiting for Micronaut server threads", ex);
+        return;
+      }
+    }
+
+    var leaked = serverThreads.stream().filter(Thread::isAlive).map(Thread::getName).toList();
+    if (!leaked.isEmpty()) {
+      throw new UnrecoverableException(
+          "Micronaut server threads did not terminate within "
+              + timeoutMs
+              + "ms after the ApplicationContext was stopped: "
+              + leaked
+              + ". Configure '"
+              + DevServerSettings.LiveReloadThreadInterruptTimeout
+              + "' to adjust the timeout.");
+    }
+  }
+
+  /** Live threads of the current reload generation, identified by the reloaded class loader. */
+  private static List<Thread> applicationThreads(ClassLoader cl) {
+    ThreadGroup root = Thread.currentThread().getThreadGroup();
+    while (root.getParent() != null) {
+      root = root.getParent();
+    }
+
+    Thread[] threads;
+    int count;
+    int size = Math.max(root.activeCount() * 2, 64);
+    do {
+      threads = new Thread[size];
+      count = root.enumerate(threads, true);
+      size *= 2;
+    } while (count == threads.length);
+
+    var current = Thread.currentThread();
+    var result = new ArrayList<Thread>();
+    for (int i = 0; i < count; i++) {
+      Thread t = threads[i];
+      if (t != current && t.isAlive() && t.getContextClassLoader() == cl) {
+        result.add(t);
+      }
+    }
+    return result;
+  }
+}

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadMicronautTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadMicronautTest.kt
@@ -1,0 +1,170 @@
+package me.seroperson.reload.live.gradle
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class LiveReloadMicronautTest : LiveReloadTestBase() {
+    @field:TempDir lateinit var projectDir: File
+
+    private val appCode by lazy {
+        val javaSources = projectDir.resolve("src/main/java/com/example")
+        javaSources.mkdirs()
+        javaSources.resolve("Application.java")
+    }
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+
+    @Test
+    fun `reload micronaut`() {
+        settingsFile.writeText(SETTINGS_CONTENT)
+        buildFile.writeText(BUILD_CONTENT)
+        appCode.writeText(APP_CODE_1)
+
+        val runner = initGradleRunner(":liveReloadRun", projectDir)
+        val isBuildRunning = AtomicBoolean(true)
+        val runThread =
+            Thread {
+                try {
+                    runner.build()
+                    isBuildRunning.set(false)
+                } catch (_: InterruptedException) {
+                    println("Interrupted")
+                } catch (ex: Exception) {
+                    println("Got exception ${ex.message}")
+                }
+            }
+        runThread.start()
+
+        val greet = runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "Hello World")
+
+        appCode.writeText(APP_CODE_2)
+
+        val greetReloaded =
+            runUntil(isBuildRunning, "http://localhost:9000/greet_reloaded", 200, "World Hello")
+
+        runThread.interrupt()
+
+        assertTrue(greet && greetReloaded)
+    }
+
+    companion object {
+        const val SETTINGS_CONTENT = ""
+        const val BUILD_CONTENT =
+            """
+plugins {
+    java
+    application
+    id("me.seroperson.reload.live.gradle")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    annotationProcessor(platform("io.micronaut.platform:micronaut-platform:4.7.6"))
+    annotationProcessor("io.micronaut:micronaut-inject-java")
+    implementation(platform("io.micronaut.platform:micronaut-platform:4.7.6"))
+    implementation("io.micronaut:micronaut-http-server-netty")
+    implementation("io.micronaut.serde:micronaut-serde-jackson")
+    runtimeOnly("ch.qos.logback:logback-classic")
+}
+
+liveReload {
+    settings =
+        mapOf(
+            "live.reload.http.port" to "8081",
+        )
+    shutdownHooks.set(
+        listOf(
+            "me.seroperson.reload.live.hook.MicronautAppShutdownHook",
+            "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook",
+        ),
+    )
+}
+
+application { mainClass = "com.example.Application" }
+"""
+        const val APP_CODE_1 =
+            """
+package com.example;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        System.setProperty("micronaut.server.port", "8081");
+        // Scan the reloaded class loader for beans, not Micronaut's own.
+        Micronaut.build(args)
+            .classLoader(Application.class.getClassLoader())
+            .mainClass(Application.class)
+            .start();
+    }
+}
+
+@Controller
+class GreetController {
+
+    @Get("/greet")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String greet() {
+        return "Hello World";
+    }
+
+    @Get("/health")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String health() {
+        return "OK";
+    }
+}
+"""
+        const val APP_CODE_2 =
+            """
+package com.example;
+
+import io.micronaut.http.MediaType;
+import io.micronaut.http.annotation.Controller;
+import io.micronaut.http.annotation.Get;
+import io.micronaut.http.annotation.Produces;
+import io.micronaut.runtime.Micronaut;
+
+public class Application {
+    public static void main(String[] args) {
+        System.setProperty("micronaut.server.port", "8081");
+        // Scan the reloaded class loader for beans, not Micronaut's own.
+        Micronaut.build(args)
+            .classLoader(Application.class.getClassLoader())
+            .mainClass(Application.class)
+            .start();
+    }
+}
+
+@Controller
+class GreetController {
+
+    @Get("/greet_reloaded")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String greet() {
+        return "World Hello";
+    }
+
+    @Get("/health")
+    @Produces(MediaType.TEXT_PLAIN)
+    public String health() {
+        return "OK";
+    }
+}
+"""
+    }
+}

--- a/mill/src/HookBundle.scala
+++ b/mill/src/HookBundle.scala
@@ -40,6 +40,16 @@ case object CaskAppHookBundle extends HookBundle {
   )
 }
 
+case object MicronautAppHookBundle extends HookBundle {
+  def startupHooks: Seq[String] = Seq(
+    HookClassnames.RestApiHealthCheckStartup
+  )
+  def shutdownHooks: Seq[String] = Seq(
+    HookClassnames.MicronautAppShutdown,
+    HookClassnames.RestApiHealthCheckShutdown
+  )
+}
+
 case object GrpcAppHookBundle extends HookBundle {
   def startupHooks: Seq[String] = Seq(
     HookClassnames.GrpcHealthCheckStartup

--- a/mill/src/HookClassnames.scala
+++ b/mill/src/HookClassnames.scala
@@ -10,6 +10,7 @@ object HookClassnames {
   val IoAppShutdown = "me.seroperson.reload.live.hook.io.IoAppShutdownHook"
   val ZioAppShutdown = "me.seroperson.reload.live.hook.zio.ZioAppShutdownHook"
   val RuntimeShutdown = "me.seroperson.reload.live.hook.RuntimeShutdownHook"
+  val MicronautAppShutdown = "me.seroperson.reload.live.hook.MicronautAppShutdownHook"
   val RestApiHealthCheckShutdown = "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook"
   val GrpcHealthCheckShutdown = "me.seroperson.reload.live.webserver.grpc.hook.GrpcHealthCheckShutdownHook"
   val ThreadInterruptShutdown = "me.seroperson.reload.live.hook.ThreadInterruptShutdownHook"

--- a/mill/src/LiveReloadModule.scala
+++ b/mill/src/LiveReloadModule.scala
@@ -85,6 +85,7 @@ trait LiveReloadModule extends JavaModule {
       if (has("zio-http")) Some(ZioAppHookBundle)
       else if (has("http4s")) Some(IoAppHookBundle)
       else if (has("cask")) Some(CaskAppHookBundle)
+      else if (has("micronaut")) Some(MicronautAppHookBundle)
       else if (has("zio")) Some(ZioAppHookBundle)
       else if (has("cats-effect")) Some(IoAppHookBundle)
       else None

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/HookBundle.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/HookBundle.scala
@@ -40,6 +40,16 @@ case object CaskAppHookBundle extends HookBundle {
   )
 }
 
+case object MicronautAppHookBundle extends HookBundle {
+  def startupHooks: Seq[String] = Seq(
+    LiveKeys.HookClassnames.RestApiHealthCheckStartup
+  )
+  def shutdownHooks: Seq[String] = Seq(
+    LiveKeys.HookClassnames.MicronautAppShutdown,
+    LiveKeys.HookClassnames.RestApiHealthCheckShutdown
+  )
+}
+
 case object GrpcAppHookBundle extends HookBundle {
   def startupHooks: Seq[String] = Seq(
     LiveKeys.HookClassnames.GrpcHealthCheckStartup

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveKeys.scala
@@ -26,6 +26,7 @@ object LiveKeys {
     val IoAppShutdown = "me.seroperson.reload.live.hook.io.IoAppShutdownHook"
     val ZioAppShutdown = "me.seroperson.reload.live.hook.zio.ZioAppShutdownHook"
     val RuntimeShutdown = "me.seroperson.reload.live.hook.RuntimeShutdownHook"
+    val MicronautAppShutdown = "me.seroperson.reload.live.hook.MicronautAppShutdownHook"
     val RestApiHealthCheckShutdown = "me.seroperson.reload.live.hook.RestApiHealthCheckShutdownHook"
     val GrpcHealthCheckShutdown = "me.seroperson.reload.live.webserver.grpc.hook.GrpcHealthCheckShutdownHook"
     val ThreadInterruptShutdown = "me.seroperson.reload.live.hook.ThreadInterruptShutdownHook"

--- a/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveReloadPlugin.scala
+++ b/sbt/src/main/scala/me/seroperson/reload/live/sbt/LiveReloadPlugin.scala
@@ -76,6 +76,8 @@ object LiveReloadPlugin extends AutoPlugin {
               IoAppHookBundle
             case lib if SbtCompat.fileName(lib.data).startsWith("cask") =>
               CaskAppHookBundle
+            case lib if SbtCompat.fileName(lib.data).startsWith("micronaut") =>
+              MicronautAppHookBundle
           }
       }
     ),


### PR DESCRIPTION
## Summary

Closes #93

Micronaut applications could not be live reloaded. `Micronaut.run(...)` starts the embedded Netty server on its own threads and returns, leaving no main thread for the generic interrupt hook to stop, so the old server kept running across a reload. This adds `MicronautAppShutdownHook`, which stops the `ApplicationContext` (via the JVM shutdown hook Micronaut registers) and joins its server threads, matched by the reloaded class loader so nothing leaks between generations. The hook ships as `MicronautAppHookBundle`, picked up automatically by sbt and mill when a `micronaut` artifact is on the classpath, and wired explicitly for Gradle.

It also documents the one application change Micronaut needs under live reload: starting through `Micronaut.build(args).classLoader(Application.class.getClassLoader()).mainClass(Application.class).start()`, so the reloaded class loader is scanned for beans instead of the framework's own (otherwise every route returns 404).

## How was it tested?

New test: `gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadMicronautTest.kt`. It drives a real Micronaut 4.7.6 application through a full reload:

- the first generation answers `GET /greet` with `Hello World`,
- the source is rewritten to expose `GET /greet_reloaded`,
- the second generation answers it with `World Hello`.

The second response only succeeds once the previous `ApplicationContext` has released its HTTP port during shutdown, so the test also covers `/health` gating and a clean stop with no leaked server threads. Run it with `just test-gradle` after publishing the core artifacts (`just publish-local-sbt`) so the plugin picks up the new hook.

> Note: the test uses the default proxy port `9000`, like the other functional tests. On a machine where `9000` is already in use, override `live.reload.proxy.http.port` locally.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [x] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
