### PR TITLE
feat: add Spark Java fixture and tested-frameworks row

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,12 @@ whether their own setup will work.
     <td>Everything from <a href="#changes-to-the-application-code">this section</a>.</td>
   </tr>
   <tr>
+    <td><a href="https://github.com/perwendel/spark">spark</a> (com.sparkjava)</td>
+    <td><i>spark-core</i> <b>2.9.4</b></td>
+    <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/plugin/plugin/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSparkTest.kt">LiveReloadSparkTest.kt</a></td>
+    <td>Call <code>Spark.stop()</code> on <code>InterruptedException</code> plus everything from <a href="#changes-to-the-application-code">this section</a>.</td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/grpc/grpc-java">grpc-java</a> (Kotlin, unary + streaming + reflection + TLS)</td>
     <td><i>grpc-java</i> <b>1.72.0</b></td>
     <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcTest.kt">LiveReloadGrpcTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcStreamingTest.kt">LiveReloadGrpcStreamingTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcReflectionTest.kt">LiveReloadGrpcReflectionTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcTlsTest.kt">LiveReloadGrpcTlsTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcMultiprojectTest.kt">LiveReloadGrpcMultiprojectTest.kt</a></td>

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSparkTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSparkTest.kt
@@ -1,0 +1,114 @@
+package me.seroperson.reload.live.gradle
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class LiveReloadSparkTest : LiveReloadTestBase() {
+    @field:TempDir lateinit var projectDir: File
+
+    private val appCode by lazy {
+        val kotlinSources = projectDir.resolve("src/main/kotlin")
+        kotlinSources.mkdirs()
+        kotlinSources.resolve("App.kt")
+    }
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+
+    @Test
+    fun `reload spark`() {
+        settingsFile.writeText(SETTINGS_CONTENT)
+        buildFile.writeText(BUILD_CONTENT)
+        appCode.writeText(APP_CODE_1)
+
+        val runner = initGradleRunner(":liveReloadRun", projectDir)
+        val isBuildRunning = AtomicBoolean(true)
+        val runThread =
+            Thread {
+                try {
+                    runner.build()
+                    isBuildRunning.set(false)
+                } catch (_: InterruptedException) {
+                    println("Interrupted")
+                } catch (ex: Exception) {
+                    println("Got exception ${ex.message}")
+                }
+            }
+        runThread.start()
+
+        val greet = runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "Hello World")
+
+        appCode.writeText(APP_CODE_2)
+
+        val greetReloaded =
+            runUntil(isBuildRunning, "http://localhost:9000/greet_reloaded", 200, "World Hello")
+
+        runThread.interrupt()
+
+        assertTrue(greet && greetReloaded)
+    }
+
+    companion object {
+        const val SETTINGS_CONTENT = ""
+        const val BUILD_CONTENT =
+            """
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    application
+    id("me.seroperson.reload.live.gradle")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.sparkjava:spark-core:2.9.4")
+}
+
+liveReload { settings = mapOf("live.reload.http.port" to "8081") }
+
+application { mainClass = "AppKt" }
+"""
+        const val APP_CODE_1 =
+            """
+import spark.Spark
+
+fun main() {
+    Spark.port(8081)
+    Spark.get("/greet") { _, _ -> "Hello World" }
+    Spark.get("/health") { _, _ -> "" }
+    Spark.awaitInitialization()
+    try {
+        Thread.currentThread().join()
+    } catch (ex: InterruptedException) {
+        Spark.stop()
+        Spark.awaitStop()
+    }
+}
+"""
+        const val APP_CODE_2 =
+            """
+import spark.Spark
+
+fun main() {
+    Spark.port(8081)
+    Spark.get("/greet_reloaded") { _, _ -> "World Hello" }
+    Spark.get("/health") { _, _ -> "" }
+    Spark.awaitInitialization()
+    try {
+        Thread.currentThread().join()
+    } catch (ex: InterruptedException) {
+        Spark.stop()
+        Spark.awaitStop()
+    }
+}
+"""
+    }
+}


### PR DESCRIPTION
## Summary

Spark Java (`com.sparkjava`) works with the default HTTP hooks once its `main` is interruptible, so no new hook bundle is needed. This adds a Gradle functional test that proves a Spark Java app reloads behind the proxy, and documents it in the tested frameworks table.

Closes #95 

The new `LiveReloadSparkTest.kt` follows the same shape as the existing Javalin and http4k fixtures:

- Brings up a Spark Java app on the application port behind the proxy.
- Exposes `/greet` and `/health`, blocks the main thread, and on `InterruptedException` shuts down with `Spark.stop()` followed by `Spark.awaitStop()` so the port is released before the reloaded instance rebinds it.
- Asserts `/greet` returns `Hello World`, rewrites the route, and asserts the reloaded `/greet_reloaded` returns `World Hello`.

The README gains one row for `spark` (`spark-core 2.9.4`) linking to the new test, noting the only application change is calling `Spark.stop()` on `InterruptedException`.

## How was it tested?

New test: `gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadSparkTest.kt`.

Ran the functional test locally against JDK 17. It reloads the app and confirms `/greet` returns `200 Hello World`, then after editing the source the reloaded `/greet_reloaded` returns `200 World Hello`. `spotlessCheck` passes.

## Checklist

- [x] Ran the relevant test recipe locally (`just test-gradle`)
- [x] Ran `just code-format-check-all` and it passes
- [x] Updated `README.md` since this adds a supported framework
- [x] Updated the tested frameworks table since this adds framework support
- [x] No unrelated files were reformatted or refactored
