### PR TITLE
feat: add Jooby to tested frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -606,6 +606,12 @@ whether their own setup will work.
     <td>Everything from <a href="#changes-to-the-application-code">this section</a>.</td>
   </tr>
   <tr>
+    <td><a href="https://github.com/jooby-project/jooby">jooby</a></td>
+    <td><i>jooby</i> <b>3.6.1</b></td>
+    <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadJoobyTest.kt">LiveReloadJoobyTest.kt</a></td>
+    <td>Everything from <a href="#changes-to-the-application-code">this section</a>.</td>
+  </tr>
+  <tr>
     <td><a href="https://github.com/grpc/grpc-java">grpc-java</a> (Kotlin, unary + streaming + reflection + TLS)</td>
     <td><i>grpc-java</i> <b>1.72.0</b></td>
     <td><a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcTest.kt">LiveReloadGrpcTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcStreamingTest.kt">LiveReloadGrpcStreamingTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcReflectionTest.kt">LiveReloadGrpcReflectionTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcTlsTest.kt">LiveReloadGrpcTlsTest.kt</a>, <a href="https://github.com/seroperson/jvm-live-reload/blob/main/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadGrpcMultiprojectTest.kt">LiveReloadGrpcMultiprojectTest.kt</a></td>

--- a/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadJoobyTest.kt
+++ b/gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadJoobyTest.kt
@@ -1,0 +1,119 @@
+package me.seroperson.reload.live.gradle
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Timeout
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.test.Test
+
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class LiveReloadJoobyTest : LiveReloadTestBase() {
+    @field:TempDir lateinit var projectDir: File
+
+    private val appCode by lazy {
+        val kotlinSources = projectDir.resolve("src/main/kotlin")
+        kotlinSources.mkdirs()
+        kotlinSources.resolve("App.kt")
+    }
+    private val buildFile by lazy { projectDir.resolve("build.gradle.kts") }
+    private val settingsFile by lazy { projectDir.resolve("settings.gradle.kts") }
+
+    @Test
+    fun `reload jooby`() {
+        settingsFile.writeText(SETTINGS_CONTENT)
+        buildFile.writeText(BUILD_CONTENT)
+        appCode.writeText(APP_CODE_1)
+
+        val runner = initGradleRunner(":liveReloadRun", projectDir)
+        val isBuildRunning = AtomicBoolean(true)
+        val runThread =
+            Thread {
+                try {
+                    runner.build()
+                    isBuildRunning.set(false)
+                } catch (_: InterruptedException) {
+                    println("Interrupted")
+                } catch (ex: Exception) {
+                    println("Got exception ${ex.message}")
+                }
+            }
+        runThread.start()
+
+        val greet = runUntil(isBuildRunning, "http://localhost:9000/greet", 200, "Hello World")
+
+        appCode.writeText(APP_CODE_2)
+
+        val greetReloaded =
+            runUntil(isBuildRunning, "http://localhost:9000/greet_reloaded", 200, "World Hello")
+
+        runThread.interrupt()
+
+        assertTrue(greet && greetReloaded)
+    }
+
+    companion object {
+        const val SETTINGS_CONTENT = ""
+        const val BUILD_CONTENT =
+            """
+plugins {
+    id("org.jetbrains.kotlin.jvm") version "2.2.0"
+    application
+    id("me.seroperson.reload.live.gradle")
+}
+
+repositories {
+    mavenLocal()
+    mavenCentral()
+}
+
+dependencies {
+    implementation("io.jooby:jooby-kotlin:3.6.1")
+    implementation("io.jooby:jooby-netty:3.6.1")
+}
+
+liveReload { settings = mapOf("live.reload.http.port" to "8081") }
+
+application { mainClass = "AppKt" }
+"""
+        const val APP_CODE_1 =
+            """
+import io.jooby.StatusCode
+import io.jooby.kt.Kooby
+
+fun main() {
+    val app = Kooby {
+        serverOptions { port = 8081 }
+        get("/greet") { "Hello World" }
+        get("/health") { ctx.send(StatusCode.OK) }
+    }
+    try {
+        app.start()
+        Thread.currentThread().join()
+    } catch (ex: InterruptedException) {
+        app.stop()
+    }
+}
+"""
+        const val APP_CODE_2 =
+            """
+import io.jooby.StatusCode
+import io.jooby.kt.Kooby
+
+fun main() {
+    val app = Kooby {
+        serverOptions { port = 8081 }
+        get("/greet_reloaded") { "World Hello" }
+        get("/health") { ctx.send(StatusCode.OK) }
+    }
+    try {
+        app.start()
+        Thread.currentThread().join()
+    } catch (ex: InterruptedException) {
+        app.stop()
+    }
+}
+"""
+    }
+}


### PR DESCRIPTION
## Summary

Jooby exposes a clean `app.stop()` and runs an interruptible main, so it fits the default lifecycle and works with the default hooks without a new hook bundle. This adds a Gradle functional test that reloads a Jooby app and a row in the tested frameworks table so the support is documented and covered.

Closes #97 

## How was it tested?

New test: `gradle/src/functionalTest/kotlin/me.seroperson.reload.live.gradle/LiveReloadJoobyTest.kt`.

It starts a Jooby app on `8081` behind the live-reload proxy, asserts `/greet` returns `Hello World`, rewrites the source to expose `/greet_reloaded`, and asserts the reloaded route returns `World Hello`. The `/health` endpoint lets the runner detect readiness, so a passing run confirms the reload path works end to end. Verified locally against a real Gradle build and the run passed.

## Checklist

- [x] I ran the relevant test recipe locally (`just test-sbt` / `just test-gradle` / `just test-mill`)
- [x] I ran `just code-format-check-all` and it passes
- [x] I updated `README.md` if this changes a config key, hook, hook bundle or supported framework
- [x] I updated the [tested frameworks table](../README.md#list-of-tested-frameworks) if this adds or upgrades framework support
- [x] No unrelated files were reformatted or refactored
