### PR TITLE
fix: remove dead code and duplicated logic in runner module

### DIFF
--- a/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
+++ b/core/runner/src/main/java/me/seroperson/reload/live/runner/DevServerReloader.java
@@ -124,46 +124,6 @@ final class DevServerReloader implements BuildLink, Closeable {
             new NamedURLClassLoader(
                 "iteration(" + iteration + ")", urls(cp), dependenciesClassLoader);
 
-        /*
-        @formatter:off
-        System.out.println("Got classpath: " + cp);
-        cp.stream().forEach((file) -> {
-          try {
-            var path = java.nio.file.Paths.get("/", "home", "seroperson", "out");
-            Files.list(file.toPath()).forEach((p) -> {
-              try {
-                System.out.println("Copying path: " + p + " to "
-                    + path.resolve(p.getFileName().toString() + "." + classLoaderVersion.get()));
-                Files.copy(p,
-                    path.resolve(p.getFileName().toString() + "." + classLoaderVersion.get()));
-              } catch (IOException e) {
-                e.printStackTrace();
-              }
-            });
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-        });
-        @formatter:on
-        */
-
-        /*
-        @formatter:off
-        System.out.println("Got classpath: " + cp);
-        cp.stream().forEach((file) -> {
-          try {
-            var path = java.nio.file.Paths.get("/", "home", "seroperson", "out");
-            System.out.println("Copying path: " + file.toPath() + " to " + path
-                .resolve(file.toPath().getFileName().toString() + "." + classLoaderVersion.get()));
-            Files.copy(file.toPath(), path
-                .resolve(file.toPath().getFileName().toString() + "." + classLoaderVersion.get()));
-          } catch (Exception e) {
-            e.printStackTrace();
-          }
-        });
-        @formatter:on
-        */
-
         return new ReloadGeneration(iteration, currentApplicationClassLoader);
       }
       return null; // null means nothing changed

--- a/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRun.kt
+++ b/gradle/src/main/kotlin/me.seroperson.reload.live.gradle/LiveReloadRun.kt
@@ -76,13 +76,7 @@ abstract class LiveReloadRun
                     logger.info("Reload application by incremental changes in application classpath")
                     runHandle.markChanged()
                 } else {
-                    if (!changes.isIncremental) {
-                        logger.info("Reload application by no incremental changes")
-                    } else if (changes.getFileChanges(this.classes).iterator().hasNext()) {
-                        logger.info("Reload application by incremental changes in application classpath")
-                    } else {
-                        logger.info("Incremental changes in Assets")
-                    }
+                    logger.info("Incremental changes in Assets")
                 }
             }
         }


### PR DESCRIPTION
## Motivation

While reviewing the runner module, I found two clear instances of dead code that should be cleaned up:

1. **Duplicated else-block in `LiveReloadRun.run()`** — The inner block repeated the exact same `isIncremental` / `getFileChanges` checks already handled by the outer block, making it unreachable dead code.
2. **Commented-out debug blocks in `DevServerReloader.reload()`** — Two large commented-out blocks (40 lines) containing hardcoded developer paths (`/home/seroperson/out`) that serve no purpose in production code.

## Changes

### `LiveReloadRun.kt` (Gradle plugin)
- Removed the duplicated inner `if-else` block in `run()`. The outer block already handles all three cases (`!isIncremental`, `getFileChanges has next`, else → "Incremental changes in Assets"), so the inner block was dead code that could never execute.

### `DevServerReloader.java` (Core runner)
- Removed two commented-out debug blocks (~40 lines) that were developer scratch code for copying classpath files to a hardcoded local path.

## Testing

- The changes are purely subtractive (dead code removal), so existing behavior is preserved.
- Verified the Gradle plugin logic: the three branches (`!isIncremental`, class changes, asset changes) are still correctly handled.
- No new tests needed — this is a cleanup PR that removes unreachable code.